### PR TITLE
Fix github path

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,8 @@ screenshot is worth a thousand words:
 Mop is implemented in Go and compiles down to a single executable file.
 
     # Make sure your $GOPATH is set.
-    $ go get github.com/michaeldv/mop
-    $ cd $GOPATH/src/github.com/michaeldv/mop
+    $ go get github.com/mop-tracker/mop
+    $ cd $GOPATH/src/github.com/mop-tracker/mop
     $ make            # <-- Compile and run mop.
     $ make build      # <-- Build mop in current directory.
     $ make install    # <-- Build mop and install it in $GOPATH/bin.


### PR DESCRIPTION
Replaced previous github URL (github.com/michaeldv/mop) for project with the current one (github.com/mop-tracker/mop) in the README.

Cheers,
Aaron ([insp3ctre](https://twitter.com/insp3ctre))