### PR TITLE
Update filepath in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Mop is implemented in Go and compiles down to a single executable file.
 
     # Make sure your $GOPATH is set.
     $ go get github.com/mop-tracker/mop/cmd/mop
-    $ cd $GOPATH/src/github.com/mop-tracker/mop/cmd/mop
+    $ cd $GOPATH/src/github.com/mop-tracker/mop
     $ make            # <-- Compile and run mop.
     $ make build      # <-- Build mop in current directory.
     $ make install    # <-- Build mop and install it in $GOPATH/bin.


### PR DESCRIPTION
Previously, if you changed into `$GOPATH/src/github.com/mop-tracker/mop/cmd/mop` and run any of the make commands you will get an error like `make: *** No targets specified and no makefile found.  Stop.`

running `cd ../..` brings you to `$GOPATH/src/github.com/mop-tracker/mop/` where all of the commands will complete.