### PR TITLE
Solved filter.go:28:21: undefined: strings

### DIFF
--- a/filter.go
+++ b/filter.go
@@ -4,6 +4,8 @@
 
 package mop
 
+import "strings"
+
 // Filter gets called to sort stock quotes by one of the columns. The
 // setup is rather lengthy; there should probably be more concise way
 // that uses reflection and avoids hardcoding the column names.


### PR DESCRIPTION
Issue : filter.go:28:21: undefined: strings
OS : MacOS mojave
Go Version : go1.13.5 darwin/amd64 (Installed with brew)

Fix : import strings