### PR TITLE
Update to go modules

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 # be found in the LICENSE file.
 
 VERSION = 0.2.0
-PACKAGE = github.com/mop-tracker/mop/cmd/mop
+PACKAGE = ./cmd/mop
 
 run:
 	go run ./cmd/mop/main.go

--- a/README.md
+++ b/README.md
@@ -10,12 +10,10 @@ screenshot is worth a thousand words:
 Mop is implemented in Go and compiles down to a single executable file.
 
     # Make sure your $GOPATH is set.
-    $ go get github.com/mop-tracker/mop/cmd/mop
-    $ cd $GOPATH/src/github.com/mop-tracker/mop
-    $ make            # <-- Compile and run mop.
-    $ make build      # <-- Build mop in current directory.
-    $ make install    # <-- Build mop and install it in $GOPATH/bin.
-
+    $ git clone https://github.com/mop-tracker/mop
+    $ cd mop
+    $ go build ./mop/cmd
+    $ ./mop
 
 ### Using Mop ###
 For demonstration purposes Mop comes preconfigured with a number of

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Mop is implemented in Go and compiles down to a single executable file.
 
     $ git clone https://github.com/mop-tracker/mop
     $ cd mop
-    $ go build ./mop/cmd
+    $ go build ./cmd/mop
     $ ./mop
 
 ### Using Mop ###

--- a/README.md
+++ b/README.md
@@ -9,7 +9,6 @@ screenshot is worth a thousand words:
 ### Installing Mop ###
 Mop is implemented in Go and compiles down to a single executable file.
 
-    # Make sure your $GOPATH is set.
     $ git clone https://github.com/mop-tracker/mop
     $ cd mop
     $ go build ./mop/cmd

--- a/README.md
+++ b/README.md
@@ -9,10 +9,7 @@ screenshot is worth a thousand words:
 ### Installing Mop ###
 Mop is implemented in Go and compiles down to a single executable file.
 
-    $ git clone https://github.com/mop-tracker/mop
-    $ cd mop
-    $ go build ./cmd/mop
-    $ ./mop
+    $ go get github.com/mop-tracker/mop/cmd/mop
 
 ### Using Mop ###
 For demonstration purposes Mop comes preconfigured with a number of

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,8 @@
+module github.com/mop-tracker/mop
+
+go 1.15
+
+require (
+	github.com/Knetic/govaluate v3.0.0+incompatible
+	github.com/nsf/termbox-go v0.0.0-20201124104050-ed494de23a00
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,7 @@
+github.com/Knetic/govaluate v1.5.0 h1:L4MyqdJSld9xr2eZcZHCWLfeIX2SBjqrwIKG1pcm/+4=
+github.com/Knetic/govaluate v3.0.0+incompatible h1:7o6+MAPhYTCF0+fdvoz1xDedhRb4f6s9Tn1Tt7/WTEg=
+github.com/Knetic/govaluate v3.0.0+incompatible/go.mod h1:r7JcOSlj0wfOMncg0iLm8Leh48TZaKVeNIfJntJ2wa0=
+github.com/mattn/go-runewidth v0.0.9 h1:Lm995f3rfxdpd6TSmuVCHVb/QhupuXlYr8sCI/QdE+0=
+github.com/mattn/go-runewidth v0.0.9/go.mod h1:H031xJmbD/WCDINGzjvQ9THkh0rPKHF+m2gUSrubnMI=
+github.com/nsf/termbox-go v0.0.0-20201124104050-ed494de23a00 h1:Rl8NelBe+n7SuLbJyw13ho7CGWUt2BjGGKIoreCWQ/c=
+github.com/nsf/termbox-go v0.0.0-20201124104050-ed494de23a00/go.mod h1:T0cTdVuOwf7pHQNtfhnEbzHbcNyCEcVU4YPpouCbVxo=


### PR DESCRIPTION
Using go modules we can remove all the extra build steps and just `go get ...`.

This also lets the repo be cloned into a local folder instead of needing to work inside of `$GOPATH`.

More details about go modules can be found [here](https://github.com/golang/go/wiki/Modules#new-concepts)