### PR TITLE
Some display and sorting fixes

### DIFF
--- a/layout.go
+++ b/layout.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 	"text/template"
 	"time"
+	"unicode"
 )
 
 var currencies = map[string]string{
@@ -54,8 +55,8 @@ func NewLayout() *Layout {
 		{10, `High`, `High`, currency},
 		{10, `Low52`, `52w Low`, currency},
 		{10, `High52`, `52w High`, currency},
-		{11, `Volume`, `Volume`, nil},
-		{11, `AvgVolume`, `AvgVolume`, nil},
+		{11, `Volume`, `Volume`, integer},
+		{11, `AvgVolume`, `AvgVolume`, integer},
 		{9, `PeRatio`, `P/E`, blank},
 		{9, `Dividend`, `Dividend`, zero},
 		{9, `Yield`, `Yield`, percent},
@@ -63,7 +64,7 @@ func NewLayout() *Layout {
 		{13, `PreOpen`, `PreMktChg%`, last},
 		{13, `AfterHours`, `AfterMktChg%`, last},
 	}
-	layout.regex = regexp.MustCompile(`(\.\d+)[BMK]?$`)
+	layout.regex = regexp.MustCompile(`(\.\d+)[TBMK]?$`)
 	layout.marketTemplate = buildMarketTemplate()
 	layout.quotesTemplate = buildQuotesTemplate()
 
@@ -269,7 +270,7 @@ func blank(str ...string) string {
 	if len(str) < 1 {
 		return "ERR"
 	}
-	if len(str[0]) == 3 && str[0][0:3] == `N/A` {
+	if (len(str[0]) == 3 && str[0][0:3] == `N/A`) || len(str[0]) == 0 {
 		return `-`
 	}
 
@@ -341,6 +342,26 @@ func percent(str ...string) string {
 	}
 	if str[0][len(str)-1] != '%' {
 		str[0] += `%`
+	}
+	return str[0]
+}
+
+// Returns value as integer (no trailing digits after a '.').
+//-----------------------------------------------------------------------------
+func integer(str ...string) string {
+	if len(str) < 1 {
+		return "ERR"
+	}
+	if str[0] == `N/A` || len(str[0]) == 0 {
+		return `-`
+	}
+
+	// Don't strip after the '.' if we have a value such as 123.45M
+	if unicode.IsDigit(rune(str[0][len(str[0])-1])) {
+		split := strings.Split(str[0], ".")
+		if len(split) == 2 {
+			return split[0]
+		}
 	}
 	return str[0]
 }

--- a/line_editor.go
+++ b/line_editor.go
@@ -5,10 +5,10 @@
 package mop
 
 import (
-	`regexp`
-	`strings`
+	"regexp"
+	"strings"
 
-	`github.com/nsf/termbox-go`
+	"github.com/nsf/termbox-go"
 )
 
 // LineEditor kicks in when user presses '+' or '-' to add or delete stock
@@ -189,7 +189,7 @@ func (editor *LineEditor) execute() *LineEditor {
 
 				// Clear the lines at the bottom of the list, if any.
 				after := before - removed
-				for i := before; i > after; i-- {
+				for i := before + 1; i > after; i-- {
 					editor.screen.ClearLine(0, i+4)
 				}
 			}

--- a/sorter.go
+++ b/sorter.go
@@ -80,10 +80,10 @@ func (list byHigh52Asc) Less(i, j int) bool {
 	return list.sortable[i].High52 < list.sortable[j].High52
 }
 func (list byVolumeAsc) Less(i, j int) bool {
-	return list.sortable[i].Volume < list.sortable[j].Volume
+	return m(list.sortable[i].Volume) < m(list.sortable[j].Volume)
 }
 func (list byAvgVolumeAsc) Less(i, j int) bool {
-	return list.sortable[i].AvgVolume < list.sortable[j].AvgVolume
+	return m(list.sortable[i].AvgVolume) < m(list.sortable[j].AvgVolume)
 }
 func (list byPeRatioAsc) Less(i, j int) bool {
 	return list.sortable[i].PeRatio < list.sortable[j].PeRatio
@@ -124,10 +124,10 @@ func (list byHigh52Desc) Less(i, j int) bool {
 	return list.sortable[j].High52 < list.sortable[i].High52
 }
 func (list byVolumeDesc) Less(i, j int) bool {
-	return list.sortable[j].Volume < list.sortable[i].Volume
+	return m(list.sortable[j].Volume) < m(list.sortable[i].Volume)
 }
 func (list byAvgVolumeDesc) Less(i, j int) bool {
-	return list.sortable[j].AvgVolume < list.sortable[i].AvgVolume
+	return m(list.sortable[j].AvgVolume) < m(list.sortable[i].AvgVolume)
 }
 func (list byPeRatioDesc) Less(i, j int) bool {
 	return list.sortable[j].PeRatio < list.sortable[i].PeRatio
@@ -221,6 +221,8 @@ func m(str string) float32 {
 	multiplier := 1.0
 
 	switch str[len(str)-1 : len(str)] { // Check the last character.
+	case `T`:
+		multiplier = 1000000000000.0
 	case `B`:
 		multiplier = 1000000000.0
 	case `M`:
@@ -229,7 +231,7 @@ func m(str string) float32 {
 		multiplier = 1000.0
 	}
 
-	trimmed := strings.Trim(str, ` $BMK`) // Get rid of non-numeric characters.
+	trimmed := strings.Trim(str, ` $TBMK`) // Get rid of non-numeric characters.
 	value, _ := strconv.ParseFloat(trimmed, 32)
 
 	return float32(value * multiplier)


### PR DESCRIPTION
- Fix sorting of trillions of $ in general.
- Fix sorting of volumes to handle billions of transactions.
- Fix display of volumes when showing less than 100K (was ending with ".00").
- Fix P/E to display `-` when data string is null or empty.
- Fix issue where the last line isn't cleared when deleting a ticker.