### PR TITLE
Bugfix for crashing on saved invalid filter

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Alternatively,
     
     $ git clone https://github.com/mop-tracker/mop
     $ cd mop
-    $ go build ./mop/cmd
+    $ go build ./cmd/mop
     $ ./mop
 
 ### Using Mop ###

--- a/cmd/mop/main.go
+++ b/cmd/mop/main.go
@@ -143,4 +143,5 @@ func main() {
 
 	profile := mop.NewProfile(*profileName)
 	mainLoop(screen, profile)
+        profile.Save()
 }

--- a/filter.go
+++ b/filter.go
@@ -50,13 +50,21 @@ func (filter *Filter) Apply(stocks []Stock) []Stock {
 		result, err := filter.profile.filterExpression.Evaluate(values)
 
 		if err != nil {
-			panic(err)
+                        // The filter isn't working, so reset to no filter.
+                        filter.profile.Filter = ""
+                        // Return an empty list.  The next main loop cycle will
+                        // show unfiltered.
+                        return filteredStocks
 		}
 
 		truthy, ok := result.(bool)
 
 		if !ok {
-			panic("Expression `" + filter.profile.Filter + "` should return a boolean value")
+                        // The filter isn't working, so reset to no filter.
+                        filter.profile.Filter = ""
+                        // Return an empty list.  The next main loop cycle will
+                        // show unfiltered.
+                        return filteredStocks
 		}
 
 		if truthy {

--- a/profile.go
+++ b/profile.go
@@ -142,5 +142,4 @@ func (profile *Profile) SetFilter(filter string) {
 	}
 
 	profile.Filter = filter
-	profile.Save()
 }


### PR DESCRIPTION
This is a bugfix that addresses the crashes in issue #82.

I made some small changes to prevent the crash. 

* Instead of a panic(err), the filter string is cleared to "" if it is found to be invalid.
* The profile is not saved in the SetFilter() function, because that saves a bad filter before it can be cleared.
* The profile is saved on program exit (exit from the main loop).
* Unrelated to this bug, I fixed a typo in the README ("go build ./mop/cmd" changed to "go build ./cmd/mop")

Note that there are still some bugs in filtering.  I'll make new issues for those.