### PR TITLE
Fixed bug where quotes list did not clear when shortened.

### DIFF
--- a/layout.go
+++ b/layout.go
@@ -165,11 +165,13 @@ func (layout *Layout) prettify(quotes *Quotes) []Stock {
 
 	profile := quotes.profile
 
-	if profile.filterExpression != nil {
-		if layout.filter == nil { // Initialize filter on first invocation.
-			layout.filter = NewFilter(profile)
+	if profile.Filter != ""{ // Fix for blank display if invalid filter expression was cleared.
+		if profile.filterExpression != nil {
+			if layout.filter == nil { // Initialize filter on first invocation.
+				layout.filter = NewFilter(profile)
+			}
+			pretty = layout.filter.Apply(pretty)
 		}
-		pretty = layout.filter.Apply(pretty)
 	}
 
 	if layout.sorter == nil { // Initialize sorter on first invocation.


### PR DESCRIPTION
If the quotes list gets shorter (e.g. by adding a filter), then display correctly overwrites the no-longer-updated quotes with blank lines.  See issue #85.