### PR TITLE
Added the mop executable (top-level only) to the gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,5 +19,6 @@ cmd/mop/debug
 # Builds and logs.
 bin/mop*
 logs/*
+/mop
 
 .idea


### PR DESCRIPTION
Just a minor change to gitignore.  It only ignores the "mop" file in the top-level directory.