### PR TITLE
Fix version number to `1.0.0` where needed

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 # Use of this source code is governed by a MIT-style license that can
 # be found in the LICENSE file.
 
-VERSION = 0.2.0
+VERSION = 1.0.0
 PACKAGE = ./cmd/mop
 
 run:

--- a/cmd/mop/main.go
+++ b/cmd/mop/main.go
@@ -17,7 +17,7 @@ import (
 // File name in user's home directory where we store the settings.
 const defaultProfile = `.moprc`
 
-const help = `Mop v0.2.0 -- Copyright (c) 2013-2016 by Michael Dvorkin. All Rights Reserved.
+const help = `Mop v1.0.0 -- Copyright (c) 2013-2022 by Michael Dvorkin. All Rights Reserved.
 NO WARRANTIES OF ANY KIND WHATSOEVER. SEE THE LICENSE FILE FOR DETAILS.
 
 <u>Command</u>    <u>Description                                </u>

--- a/homebrew/mop.rb
+++ b/homebrew/mop.rb
@@ -3,8 +3,8 @@ require "formula"
 class Mop < Formula
   homepage "https://github.com/mop-tracker/mop"
   head     "https://github.com/mop-tracker/mop.git"
-  url      "https://github.com/mop-tracker/mop/archive/v0.2.0.tar.gz"
-  sha1     "bc666ec165d08b43134f7ec0bf29083ad5466243"
+  url      "https://github.com/mop-tracker/mop/archive/refs/tags/v1.0.0.tar.gz"
+  sha1     "bc666ec165d08b43134f7ec0bf29083ad5466243" # Needs updating.
 
   depends_on "go" => :build
 


### PR DESCRIPTION
- Updated the version number in several places where they were still at `0.2.0`.
- The SHA1 still needs to be updated in the `homebrew\mop.rb` file.
- Also, accepting these changes might entails that version will now be `1.0.1`. I leave that decision the the maintainer. Update accordingly.