### PR TITLE
Adding scroll feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,8 @@ For demonstration purposes Mop comes preconfigured with a number of stock ticker
     g       Group stocks by advancing/declining issues.
     f       Set a filtering expression.
     F       Unset a filtering expression.
+    PgDn    Scroll Down, down arrow key also works.
+    PgUp    Scroll up, up arrow key also works.
     ?       Display help screen.
     esc     Quit mop.
 

--- a/cmd/mop/main.go
+++ b/cmd/mop/main.go
@@ -138,7 +138,7 @@ loop:
 				screen.Resize()
 				if !showingHelp {
 					screen.Draw(market)
-                    redrawQuotesFlag = true
+					redrawQuotesFlag = true
 				} else {
 					screen.Draw(help)
 				}
@@ -162,7 +162,8 @@ loop:
 
 		case <-quotesQueue.C:
 			if !showingHelp && !paused && len(keyboardQueue) == 0 {
-				screen.Draw(quotes)
+				go quotes.Fetch()
+				redrawQuotesFlag = true
 			}
 
 		case <-marketQueue.C:

--- a/cmd/mop/main.go
+++ b/cmd/mop/main.go
@@ -33,6 +33,8 @@ NO WARRANTIES OF ANY KIND WHATSOEVER. SEE THE LICENSE FILE FOR DETAILS.
    g       Group stocks by advancing/declining issues.
    o       Change column sort order.
    p       Pause market data and stock updates.
+   PgDn    Scroll Down, down arrow key also works.
+   PgUp    Scroll up, up arrow key also works.
    q       Quit mop.
   esc      Ditto.
 
@@ -52,6 +54,7 @@ func mainLoop(screen *mop.Screen, profile *mop.Profile) {
 	marketQueue := time.NewTicker(12 * time.Second)
 	showingHelp := false
 	paused := false
+	pgUpDownLines := 10
 
 	go func() {
 		for {
@@ -92,6 +95,14 @@ loop:
 					} else if event.Ch == '?' || event.Ch == 'h' || event.Ch == 'H' {
 						showingHelp = true
 						screen.Clear().Draw(help)
+					} else if event.Key == termbox.KeyPgdn ||
+						event.Key == termbox.KeyArrowDown {
+						screen.IncreaseOffset(pgUpDownLines, len(profile.Tickers))
+						screen.Clear().Draw(market, quotes)
+					} else if event.Key == termbox.KeyPgup ||
+						event.Key == termbox.KeyArrowUp {
+						screen.DecreaseOffset(pgUpDownLines)
+						screen.Clear().Draw(market, quotes)
 					}
 				} else if lineEditor != nil {
 					if done := lineEditor.Handle(event); done {

--- a/cmd/mop/main.go
+++ b/cmd/mop/main.go
@@ -51,7 +51,7 @@ func mainLoop(screen *mop.Screen, profile *mop.Profile) {
 	termbox.SetInputMode(termbox.InputMouse)
 
 	// use buffered channel for keyboard event queue
-	keyboardQueue := make(chan termbox.Event, 16)
+	keyboardQueue := make(chan termbox.Event, 128)
 
 	timestampQueue := time.NewTicker(1 * time.Second)
 	quotesQueue := time.NewTicker(5 * time.Second)
@@ -142,10 +142,10 @@ loop:
 				if lineEditor == nil && columnEditor == nil && !showingHelp {
 					switch event.Key {
 					case termbox.MouseWheelUp:
-						screen.DecreaseOffset(1)
+						screen.DecreaseOffset(5)
 						redrawQuotesFlag = true
 					case termbox.MouseWheelDown:
-						screen.IncreaseOffset(1, len(profile.Tickers))
+						screen.IncreaseOffset(5, len(profile.Tickers))
 						redrawQuotesFlag = true
 					}
 				}
@@ -169,6 +169,7 @@ loop:
 
 		if redrawQuotesFlag && len(keyboardQueue) == 0 {
 			screen.Draw(quotes)
+			redrawQuotesFlag = false
 		}
 	}
 }

--- a/cmd/mop/main.go
+++ b/cmd/mop/main.go
@@ -114,6 +114,10 @@ loop:
 					} else if event.Key == termbox.KeyArrowDown || event.Ch == 'j' {
 						screen.IncreaseOffset(1, len(profile.Tickers))
 						redrawQuotesFlag = true
+					} else if event.Key == termbox.KeyHome {
+						screen.ScrollTop()
+					} else if event.Key == termbox.KeyEnd {
+						screen.ScrollBottom(len(profile.Tickers))
 					}
 				} else if lineEditor != nil {
 					if done := lineEditor.Handle(event); done {

--- a/cmd/mop/main.go
+++ b/cmd/mop/main.go
@@ -69,7 +69,8 @@ func mainLoop(screen *mop.Screen, profile *mop.Profile) {
 
 	market := mop.NewMarket()
 	quotes := mop.NewQuotes(market, profile)
-	screen.Draw(market, quotes)
+	screen.Draw(market)
+	screen.Draw(quotes)
 
 loop:
 	for {
@@ -102,7 +103,7 @@ loop:
 						screen.Clear().Draw(help)
 					} else if event.Key == termbox.KeyPgdn ||
 						event.Ch == 'J' {
-						screen.IncreaseOffset(upDownJump, len(profile.Tickers))
+						screen.IncreaseOffset(upDownJump)
 						redrawQuotesFlag = true
 					} else if event.Key == termbox.KeyPgup ||
 						event.Ch == 'K' {
@@ -112,13 +113,13 @@ loop:
 						screen.DecreaseOffset(1)
 						redrawQuotesFlag = true
 					} else if event.Key == termbox.KeyArrowDown || event.Ch == 'j' {
-						screen.IncreaseOffset(1, len(profile.Tickers))
+						screen.IncreaseOffset(1)
 						redrawQuotesFlag = true
 					} else if event.Key == termbox.KeyHome {
 						screen.ScrollTop()
 						redrawQuotesFlag = true
 					} else if event.Key == termbox.KeyEnd {
-						screen.ScrollBottom(len(profile.Tickers))
+						screen.ScrollBottom()
 						redrawQuotesFlag = true
 					}
 				} else if lineEditor != nil {
@@ -136,7 +137,8 @@ loop:
 			case termbox.EventResize:
 				screen.Resize()
 				if !showingHelp {
-					screen.Draw(market, quotes)
+					screen.Draw(market)
+                    redrawQuotesFlag = true
 				} else {
 					screen.Draw(help)
 				}
@@ -147,7 +149,7 @@ loop:
 						screen.DecreaseOffset(5)
 						redrawQuotesFlag = true
 					case termbox.MouseWheelDown:
-						screen.IncreaseOffset(5, len(profile.Tickers))
+						screen.IncreaseOffset(5)
 						redrawQuotesFlag = true
 					}
 				}
@@ -159,8 +161,8 @@ loop:
 			}
 
 		case <-quotesQueue.C:
-			if !showingHelp && !paused {
-				redrawQuotesFlag = true
+			if !showingHelp && !paused && len(keyboardQueue) == 0 {
+				screen.Draw(quotes)
 			}
 
 		case <-marketQueue.C:

--- a/cmd/mop/main.go
+++ b/cmd/mop/main.go
@@ -60,6 +60,7 @@ func mainLoop(screen *mop.Screen, profile *mop.Profile) {
 	paused := false
 	upDownJump := profile.UpDownJump
 	redrawQuotesFlag := false
+	redrawMarketFlag := false
 
 	go func() {
 		for {
@@ -137,8 +138,12 @@ loop:
 			case termbox.EventResize:
 				screen.Resize()
 				if !showingHelp {
-					screen.Draw(market)
+					//screen.Draw(market)
+					//redrawQuotesFlag = true
+					//screen.Draw(market)
 					redrawQuotesFlag = true
+					redrawMarketFlag = true
+					//screen.DrawOldQuotes(quotes)
 				} else {
 					screen.Draw(help)
 				}
@@ -175,6 +180,10 @@ loop:
 		if redrawQuotesFlag && len(keyboardQueue) == 0 {
 			screen.DrawOldQuotes(quotes)
 			redrawQuotesFlag = false
+		}
+		if redrawMarketFlag && len(keyboardQueue) == 0 {
+			screen.Draw(market)
+			redrawMarketFlag = false
 		}
 	}
 }

--- a/cmd/mop/main.go
+++ b/cmd/mop/main.go
@@ -168,7 +168,7 @@ loop:
 		}
 
 		if redrawQuotesFlag && len(keyboardQueue) == 0 {
-			screen.Draw(quotes)
+			screen.DrawOldQuotes(quotes)
 			redrawQuotesFlag = false
 		}
 	}

--- a/cmd/mop/main.go
+++ b/cmd/mop/main.go
@@ -116,8 +116,10 @@ loop:
 						redrawQuotesFlag = true
 					} else if event.Key == termbox.KeyHome {
 						screen.ScrollTop()
+						redrawQuotesFlag = true
 					} else if event.Key == termbox.KeyEnd {
 						screen.ScrollBottom(len(profile.Tickers))
+						redrawQuotesFlag = true
 					}
 				} else if lineEditor != nil {
 					if done := lineEditor.Handle(event); done {
@@ -158,7 +160,7 @@ loop:
 
 		case <-quotesQueue.C:
 			if !showingHelp && !paused {
-				screen.Draw(quotes)
+				redrawQuotesFlag = true
 			}
 
 		case <-marketQueue.C:

--- a/profile.go
+++ b/profile.go
@@ -31,6 +31,7 @@ type Profile struct {
 	Ascending     bool     // True when sort order is ascending.
 	Grouped       bool     // True when stocks are grouped by advancing/declining.
 	Filter        string   // Filter in human form
+	UpDownJump    int      // Number of lines to go up/down when scrolling.
 	Colors        struct { // User defined colors
 		Gain    string
 		Loss    string
@@ -93,6 +94,10 @@ func NewProfile(filename string) (*Profile, error) {
 	}
 	profile.selectedColumn = -1
 
+	if profile.UpDownJump < 1 {
+		profile.UpDownJump = 10
+	}
+
 	return profile, err
 }
 
@@ -105,6 +110,7 @@ func (profile *Profile) InitDefaultProfile() {
 	profile.SortColumn = 0   // Stock quotes are sorted by ticker name.
 	profile.Ascending = true // A to Z.
 	profile.Filter = ""
+	profile.UpDownJump = 10
 	profile.Colors.Gain = defaultGainColor
 	profile.Colors.Loss = defaultLossColor
 	profile.Colors.Tag = defaultTagColor

--- a/screen.go
+++ b/screen.go
@@ -208,7 +208,7 @@ func (screen *Screen) draw(str string, offset bool) {
 	allLines = strings.Split(str, "\n")
 
 	if offset {
-		screen.max = len(allLines) - screen.height
+		screen.max = len(allLines) - screen.height + screen.headerLine
 	}
 
 	// Write the lines being updated.

--- a/screen.go
+++ b/screen.go
@@ -232,7 +232,7 @@ func (screen *Screen) draw(str string, offset bool) {
 				if row <= len(allLines) &&
 					row > screen.headerLine {
 					screen.DrawLineFlush(0, row-screen.offset, allLines[row], false)
-				} else if row > len(allLines) {
+				} else if row > len(allLines) + 1 {
 					row = len(allLines)
 				}
 			}

--- a/screen.go
+++ b/screen.go
@@ -92,7 +92,7 @@ func (screen *Screen) ClearLine(x int, y int) *Screen {
 // Increase the offset for scrolling feature by n
 // Takes number of tickers as max, so not scrolling down forever
 func (screen *Screen) IncreaseOffset(n int, max int) {
-	if screen.offset+n < max {
+	if screen.offset+n+1 < max {
 		screen.offset += n
 	}
 }
@@ -173,9 +173,9 @@ func (screen *Screen) draw(str string, offset bool) {
 	// Write the lines being updated.
 	for row := 0; row < len(allLines); row++ {
 		if offset {
-            // Did we draw the underlined heading row?  This is a crude
-            // check, but--see comments below...
-            // --- Heading row only appears for quotes, so offset is true
+			// Did we draw the underlined heading row?  This is a crude
+			// check, but--see comments below...
+			// --- Heading row only appears for quotes, so offset is true
 			if strings.Contains(allLines[row], "Ticker") &&
 				strings.Contains(allLines[row], "Last") &&
 				strings.Contains(allLines[row], "Change") {
@@ -189,7 +189,7 @@ func (screen *Screen) draw(str string, offset bool) {
 				}
 			}
 		} else {
-            screen.DrawLine(0, row, allLines[row])
+			screen.DrawLine(0, row, allLines[row])
 		}
 	}
 	// If the quotes lines in this cycle are shorter than in the previous
@@ -205,7 +205,7 @@ func (screen *Screen) draw(str string, offset bool) {
 	// cycle.  In that case, padding with blank lines would overwrite the
 	// stocks list.)
 	if drewHeading {
-		for i := len(allLines) - 1; i < screen.height; i++ {
+		for i := len(allLines) - 1 - screen.offset; i < screen.height; i++ {
 			screen.DrawLine(0, i, blankLine)
 		}
 	}

--- a/screen.go
+++ b/screen.go
@@ -92,7 +92,7 @@ func (screen *Screen) ClearLine(x int, y int) *Screen {
 // Increase the offset for scrolling feature by n
 // Takes number of tickers as max, so not scrolling down forever
 func (screen *Screen) IncreaseOffset(n int, max int) {
-	if screen.offset + n +1 < max {
+	if screen.offset + n + 1 < max {
 		screen.offset += n
 	}
 }
@@ -121,9 +121,8 @@ func (screen *Screen) ScrollBottom(max int) {
 
 func (screen *Screen) DrawOldQuotes(quotes *Quotes) {
     screen.draw(screen.layout.Quotes(quotes), true)
-    termbox.Flush()
+	termbox.Flush()
 }
-
 
 // Draw accepts variable number of arguments and knows how to display the
 // market data, stock quotes, current time, and an arbitrary string.
@@ -148,14 +147,22 @@ func (screen *Screen) Draw(objects ...interface{}) *Screen {
 		}
 	}
 
-    termbox.Flush()
+	termbox.Flush()
 
 	return screen
 }
 
 // DrawLine takes the incoming string, tokenizes it to extract markup
 // elements, and displays it all starting at (x,y) location.
+
+// DrawLineFlush gives the option to flush screen after drawing
+
+// wrapper for DrawLineFlush
 func (screen *Screen) DrawLine(x int, y int, str string) {
+	screen.DrawLineFlush(x, y, str, true)
+}
+
+func (screen *Screen) DrawLineFlush(x int, y int, str string, flush bool) {
 	start, column := 0, 0
 
 	for _, token := range screen.markup.Tokenize(str) {
@@ -175,31 +182,8 @@ func (screen *Screen) DrawLine(x int, y int, str string) {
 			termbox.SetCell(start, y, char, screen.markup.Foreground, screen.markup.Background)
 		}
 	}
-	termbox.Flush()
-}
-
-// Identical to DrawLine, no flush at the end perhaps should be a part
-//  of DrawLine, with a flush parameter, or a wrapper function could be
-//  used
-func (screen *Screen) DrawLineWithoutFlush(x int, y int, str string) {
-	start, column := 0, 0
-
-	for _, token := range screen.markup.Tokenize(str) {
-		// First check if it's a tag. Tags are eaten up and not displayed.
-		if screen.markup.IsTag(token) {
-			continue
-		}
-
-		// Here comes the actual text: display it one character at a time.
-		for i, char := range token {
-			if !screen.markup.RightAligned {
-				start = x + column
-				column++
-			} else {
-				start = screen.width - len(token) + i
-			}
-			termbox.SetCell(start, y, char, screen.markup.Foreground, screen.markup.Background)
-		}
+	if flush {
+		termbox.Flush()
 	}
 }
 
@@ -230,7 +214,7 @@ func (screen *Screen) draw(str string, offset bool) {
 					strings.Contains(allLines[row], "Change") {
 					drewHeading = true
 					screen.headerLine = row
-					screen.DrawLineWithoutFlush(0, row, allLines[row])
+					screen.DrawLine(0, row, allLines[row])
 					// move on to the point to offset to
 					row += screen.offset
 				}
@@ -238,13 +222,13 @@ func (screen *Screen) draw(str string, offset bool) {
 				// only write the necessary lines
 				if row <= len(allLines) &&
 					row > screen.headerLine {
-					screen.DrawLineWithoutFlush(0, row-screen.offset, allLines[row])
+					screen.DrawLineFlush(0, row-screen.offset, allLines[row], false)
 				} else if row > len(allLines) {
 					row = len(allLines)
 				}
 			}
 		} else {
-			screen.DrawLineWithoutFlush(0, row, allLines[row])
+			screen.DrawLineFlush(0, row, allLines[row], false)
 		}
 	}
 	// If the quotes lines in this cycle are shorter than in the previous
@@ -260,10 +244,10 @@ func (screen *Screen) draw(str string, offset bool) {
 	// cycle.  In that case, padding with blank lines would overwrite the
 	// stocks list.)
 	if drewHeading {
-		for i := len(allLines) - 1 - screen.offset ; i < screen.height; i++ {
-            if i > screen.headerLine {
-                screen.DrawLine(0, i, blankLine)
-            }
+		for i := len(allLines) - 1 - screen.offset; i < screen.height; i++ {
+			if i > screen.headerLine {
+				screen.DrawLine(0, i, blankLine)
+			}
 		}
 	}
 }

--- a/screen.go
+++ b/screen.go
@@ -92,7 +92,7 @@ func (screen *Screen) ClearLine(x int, y int) *Screen {
 // Increase the offset for scrolling feature by n
 // Takes number of tickers as max, so not scrolling down forever
 func (screen *Screen) IncreaseOffset(n int, max int) {
-	if screen.offset + n + 1 < max {
+    if screen.offset + n < max - screen.height + screen.headerLine{
 		screen.offset += n
 	}
 }

--- a/screen.go
+++ b/screen.go
@@ -106,6 +106,19 @@ func (screen *Screen) DecreaseOffset(n int) {
 	}
 }
 
+func (screen *Screen) ScrollTop() {
+	screen.offset = 0
+}
+
+func (screen *Screen) ScrollBottom(max int) {
+	bottom := max - screen.height + screen.headerLine
+	if bottom > 0 {
+		screen.offset = bottom
+	} else {
+		screen.offset = 0
+	}
+}
+
 // Draw accepts variable number of arguments and knows how to display the
 // market data, stock quotes, current time, and an arbitrary string.
 func (screen *Screen) Draw(objects ...interface{}) *Screen {

--- a/screen.go
+++ b/screen.go
@@ -119,6 +119,12 @@ func (screen *Screen) ScrollBottom(max int) {
 	}
 }
 
+func (screen *Screen) DrawOldQuotes(quotes *Quotes) {
+    screen.draw(screen.layout.Quotes(quotes), true)
+    termbox.Flush()
+}
+
+
 // Draw accepts variable number of arguments and knows how to display the
 // market data, stock quotes, current time, and an arbitrary string.
 func (screen *Screen) Draw(objects ...interface{}) *Screen {

--- a/screen.go
+++ b/screen.go
@@ -96,8 +96,8 @@ func (screen *Screen) IncreaseOffset(n int) {
 	if screen.offset+n <= screen.max {
 		screen.offset += n
 	} else if screen.max > screen.height {
-        screen.offset = screen.max
-    }
+		screen.offset = screen.max
+	}
 }
 
 // Decrease the offset for scrolling feature by n
@@ -114,13 +114,18 @@ func (screen *Screen) ScrollTop() {
 }
 
 func (screen *Screen) ScrollBottom() {
-    if screen.max > screen.height {
-        screen.offset = screen.max
-    }
+	if screen.max > screen.height {
+		screen.offset = screen.max
+	}
 }
 
 func (screen *Screen) DrawOldQuotes(quotes *Quotes) {
 	screen.draw(screen.layout.Quotes(quotes), true)
+	termbox.Flush()
+}
+
+func (screen *Screen) DrawOldMarket(market *Market) {
+	screen.draw(screen.layout.Market(market), false)
 	termbox.Flush()
 }
 

--- a/screen.go
+++ b/screen.go
@@ -179,6 +179,8 @@ func (screen *Screen) draw(str string, offset bool) {
 	var allLines []string
 	drewHeading := false
 
+	screen.width, screen.height = termbox.Size()
+
 	tempFormat := "%" + strconv.Itoa(screen.width) + "s"
 	blankLine := fmt.Sprintf(tempFormat, "")
 	allLines = strings.Split(str, "\n")
@@ -189,16 +191,23 @@ func (screen *Screen) draw(str string, offset bool) {
 			// Did we draw the underlined heading row?  This is a crude
 			// check, but--see comments below...
 			// --- Heading row only appears for quotes, so offset is true
-			if strings.Contains(allLines[row], "Ticker") &&
-				strings.Contains(allLines[row], "Last") &&
-				strings.Contains(allLines[row], "Change") {
-				drewHeading = true
-				screen.headerLine = row
-				screen.DrawLine(0, row, allLines[row])
+			if !drewHeading {
+				if strings.Contains(allLines[row], "Ticker") &&
+					strings.Contains(allLines[row], "Last") &&
+					strings.Contains(allLines[row], "Change") {
+					drewHeading = true
+					screen.headerLine = row
+					screen.DrawLine(0, row, allLines[row])
+					// move on to the point to offset to
+					row += screen.offset
+				}
 			} else {
-				if row+screen.offset < len(allLines) &&
+				// only write the necessary lines
+				if row <= len(allLines) &&
 					row > screen.headerLine {
-					screen.DrawLine(0, row, allLines[row+screen.offset])
+					screen.DrawLine(0, row-screen.offset, allLines[row])
+				} else if row > len(allLines) {
+					row = len(allLines)
 				}
 			}
 		} else {


### PR DESCRIPTION
Adding an 'offset' to the quotes draw function in screen.go in order to
allow moving down the list of tickers, using PgUp/PgDown or the Up/Down
arrow keys.

Currently, the offset is changed by 10 each time, and this is a hard
coded setting, but it would make sense to add this to the profile.

Also, scrolling with the mouse is not yet implemented, yet is possible
with termbox.

Initially, I set the up/down arrow to move one line at a time, but
moving one line and then trying to redraw the entire screen was
slow/laggy, so it moves 10 lines at a time currently. It might be nice
to have it move one line at a time, more line top/htop.
