### PR TITLE
Adding Docker support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,9 @@
+FROM golang:alpine
+
+RUN apk update && apk add --no-cache git
+RUN git clone https://github.com/mop-tracker/mop ./mop
+RUN cd mop && \
+    go build ./cmd/mop && \
+    chmod a+x ./mop
+WORKDIR /go/mop/
+CMD ["./mop"]


### PR DESCRIPTION
Adding a simple Dockerfile that can be built locally based on golang:alpine 

### Usage
- Build image
`docker build -t mop:latest .`

- Launch container (without profile) 
`docker run -it --name mop --rm  mop:latest`

- Launch Container with provided profile
`docker run -it --name mop --rm -v ./.moprc:/root/.moprc mop:latest`
where  ./.moprc is the path to your .moprc profile