### PR TITLE
workaround loss of direct yahoo api

### DIFF
--- a/yahoo_crumb.go
+++ b/yahoo_crumb.go
@@ -1,0 +1,89 @@
+// Copyright (c) 2013-2019 by Michael Dvorkin and contributors. All Rights Reserved.
+// Use of this source code is governed by a MIT-style license that can
+// be found in the LICENSE file.
+
+package mop
+
+import (
+	"io/ioutil"
+	"net/http"
+	"strings"
+)
+
+const crumbURL = "https://query1.finance.yahoo.com/v1/test/getcrumb"
+const cookieURL = "https://login.yahoo.com"
+const userAgent = "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:109.0) Gecko/20100101 Firefox/113.0"
+
+func fetchCrumb(cookies string) string {
+	client := http.Client{}
+	request, err := http.NewRequest("GET", crumbURL, nil)
+	if err != nil {
+		panic(err)
+	}
+
+	request.Header = http.Header{
+		"Accept":          {"*/*"},
+		"Accept-Encoding": {"gzip, deflate, br"},
+		"Accept-Language": {"en-US,en;q=0.5"},
+		"Connection":      {"keep-alive"},
+		"Content-Type":    {"text/plain"},
+		"Cookie":          {cookies},
+		"Host":            {"query1.finance.yahoo.com"},
+		"Sec-Fetch-Dest":  {"empty"},
+		"Sec-Fetch-Mode":  {"cors"},
+		"Sec-Fetch-Site":  {"same-site"},
+		"TE":              {"trailers"},
+		"User-Agent":      {userAgent},
+	}
+
+	response, err := client.Do(request)
+	if err != nil {
+		panic(err)
+	}
+	defer response.Body.Close()
+
+	body, err := ioutil.ReadAll(response.Body)
+	if err != nil {
+		panic(err)
+	}
+
+	return string(body[:])
+}
+
+func fetchCookies() string {
+	client := http.Client{}
+	request, err := http.NewRequest("GET", cookieURL, nil)
+	if err != nil {
+		panic(err)
+	}
+
+	request.Header = http.Header{
+		"Accept":                   {"*/*"},
+		"Accept-Encoding":          {"gzip, deflate, br"},
+		"Accept-Language":          {"en-US,en;q=0.5"},
+		"Connection":               {"keep-alive"},
+		"Host":                     {"login.yahoo.com"},
+		"Sec-Fetch-Dest":           {"document"},
+		"Sec-Fetch-Mode":           {"navigate"},
+		"Sec-Fetch-Site":           {"none"},
+		"Sec-Fetch-User":           {"?1"},
+		"TE":                       {"trailers"},
+		"Update-Insecure-Requests": {"1"},
+		"User-Agent":               {userAgent},
+	}
+
+	response, err := client.Do(request)
+	if err != nil {
+		panic(err)
+	}
+	defer response.Body.Close()
+
+	var result string
+	for _, cookie := range response.Cookies() {
+		if cookie.Name != "AS" {
+			result += cookie.Name + "=" + cookie.Value + "; "
+		}
+	}
+	result = strings.TrimSuffix(result, "; ")
+	return result
+}

--- a/yahoo_market.go
+++ b/yahoo_market.go
@@ -88,7 +88,7 @@ func (market *Market) Fetch() (self *Market) {
 		"Connection":      {"keep-alive"},
 		"Content-Type":    {"application/json"},
 		"Cookie":          {market.cookies},
-		"Host":            {"query2.finance.yahoo.com"},
+		"Host":            {"query1.finance.yahoo.com"},
 		"Origin":          {"https://finance.yahoo.com"},
 		"Referer":         {"https://finance.yahoo.com"},
 		"Sec-Fetch-Dest":  {"empty"},

--- a/yahoo_market.go
+++ b/yahoo_market.go
@@ -5,14 +5,13 @@
 package mop
 
 import (
+	"encoding/json"
 	"fmt"
 	"io/ioutil"
 	"net/http"
-	"encoding/json"
 )
 
-// Ongoing issue with Yahoo API version
-const marketURL = `https://query1.finance.yahoo.com/v6/finance/quote?symbols=%s`
+const marketURL = `https://query1.finance.yahoo.com/v7/finance/quote?crumb=%s&symbols=%s`
 const marketURLQueryParts = `&range=1d&interval=5m&indicators=close&includeTimestamps=false&includePrePost=false&corsDomain=finance.yahoo.com&.tsrc=finance`
 
 // Market stores current market information displayed in the top three lines of
@@ -33,6 +32,8 @@ type Market struct {
 	Gold      map[string]string
 	errors    string // Error(s), if any.
 	url       string // URL with symbols to fetch data
+	cookies   string // cookies for auth
+	crumb     string // crumb for the cookies, to be applied as a query param
 }
 
 // Returns new initialized Market struct.
@@ -54,7 +55,9 @@ func NewMarket() *Market {
 	market.Euro = make(map[string]string)
 	market.Gold = make(map[string]string)
 
-	market.url = fmt.Sprintf(marketURL, `^DJI,^IXIC,^GSPC,^N225,^HSI,^FTSE,^GDAXI,^TNX,CL=F,JPY=X,EUR=X,GC=F`) + marketURLQueryParts
+	market.cookies = fetchCookies()
+	market.crumb = fetchCrumb(market.cookies)
+	market.url = fmt.Sprintf(marketURL, market.crumb, `^DJI,^IXIC,^GSPC,^N225,^HSI,^FTSE,^GDAXI,^TNX,CL=F,JPY=X,EUR=X,GC=F`) + marketURLQueryParts
 
 	market.errors = ``
 
@@ -73,7 +76,29 @@ func (market *Market) Fetch() (self *Market) {
 		}
 	}()
 
-	response, err := http.Get(market.url)
+	client := http.Client{}
+	request, err := http.NewRequest("GET", market.url, nil)
+	if err != nil {
+		panic(err)
+	}
+
+	request.Header = http.Header{
+		"Accept":          {"*/*"},
+		"Accept-Language": {"en-US,en;q=0.5"},
+		"Connection":      {"keep-alive"},
+		"Content-Type":    {"application/json"},
+		"Cookie":          {market.cookies},
+		"Host":            {"query2.finance.yahoo.com"},
+		"Origin":          {"https://finance.yahoo.com"},
+		"Referer":         {"https://finance.yahoo.com"},
+		"Sec-Fetch-Dest":  {"empty"},
+		"Sec-Fetch-Mode":  {"cors"},
+		"Sec-Fetch-Site":  {"same-site"},
+		"TE":              {"trailers"},
+		"User-Agent":      {userAgent},
+	}
+
+	response, err := client.Do(request)
 	if err != nil {
 		panic(err)
 	}
@@ -102,39 +127,39 @@ func (market *Market) isMarketOpen(body []byte) []byte {
 
 // -----------------------------------------------------------------------------
 func assign(results []map[string]interface{}, position int, changeAsPercent bool) map[string]string {
-    out := make(map[string]string)
+	out := make(map[string]string)
 	out[`change`] = float2Str(results[position]["regularMarketChange"].(float64))
-        out[`latest`] = float2Str(results[position]["regularMarketPrice"].(float64))
-    if changeAsPercent{
-        out[`change`] = float2Str(results[position]["regularMarketChangePercent"].(float64)) + `%`
-    } else { 
-        out[`percent`] = float2Str(results[position]["regularMarketChangePercent"].(float64))
-    }
-    return out
+	out[`latest`] = float2Str(results[position]["regularMarketPrice"].(float64))
+	if changeAsPercent {
+		out[`change`] = float2Str(results[position]["regularMarketChangePercent"].(float64)) + `%`
+	} else {
+		out[`percent`] = float2Str(results[position]["regularMarketChangePercent"].(float64))
+	}
+	return out
 }
 
 // -----------------------------------------------------------------------------
 func (market *Market) extract(body []byte) *Market {
-    d := map[string]map[string][]map[string]interface{}{}
-    err := json.Unmarshal(body, &d)
-    if err != nil {
-        panic(err)
-    }
-    results := d["quoteResponse"]["result"]
-    market.Dow = assign(results, 0, false)
-    market.Nasdaq = assign(results, 1, false)
-    market.Sp500 = assign(results, 2, false)
-    market.Tokyo = assign(results, 3, false)
-    market.HongKong = assign(results, 4, false)
-    market.London = assign(results, 5, false)
-    market.Frankfurt = assign(results, 6, false)
-    market.Yield[`name`] = `10-year Yield`
-    market.Yield = assign(results, 7, false)
+	d := map[string]map[string][]map[string]interface{}{}
+	err := json.Unmarshal(body, &d)
+	if err != nil {
+		panic(err)
+	}
+	results := d["quoteResponse"]["result"]
+	market.Dow = assign(results, 0, false)
+	market.Nasdaq = assign(results, 1, false)
+	market.Sp500 = assign(results, 2, false)
+	market.Tokyo = assign(results, 3, false)
+	market.HongKong = assign(results, 4, false)
+	market.London = assign(results, 5, false)
+	market.Frankfurt = assign(results, 6, false)
+	market.Yield[`name`] = `10-year Yield`
+	market.Yield = assign(results, 7, false)
 
-    market.Oil = assign(results, 8, true)
-    market.Yen = assign(results, 9, true)
-    market.Euro = assign(results, 10, true)
-    market.Gold = assign(results, 11, true)
+	market.Oil = assign(results, 8, true)
+	market.Yen = assign(results, 9, true)
+	market.Euro = assign(results, 10, true)
+	market.Gold = assign(results, 11, true)
 
-    return market
+	return market
 }

--- a/yahoo_quotes.go
+++ b/yahoo_quotes.go
@@ -15,16 +15,13 @@ import (
 	"strings"
 )
 
-// https://query1.finance.yahoo.com/v8/finance/chart/AAPL?region=US&lang=en-US&includePrePost=false&interval=2m&useYfid=true&range=1d&corsDomain=finance.yahoo.com&.tsrc=finance
-
-// https://query2.finance.yahoo.com/v7/finance/quote?symbols=AAPL&formatted=true&crumb=kMlYCsQaDFr&lang=en-US&region=US&corsDomain=finance.yahoo.com&fields=exchangeTimezoneName%2CexchangeTimezoneShortName%2CregularMarketTime%2CgmtOffSetMilliseconds
-
-// https://query1.finance.yahoo.com/v1/test/getcrumb
-
 // Ongoing issue with Yahoo API version
 // const quotesURLv7 = `https://query1.finance.yahoo.com/v7/finance/quote?symbols=%s`
-// //const quotesURL = `https://query1.finance.yahoo.com/v6/finance/quote?symbols=%s`
-const quotesURL = `https://query2.finance.yahoo.com/v7/finance/quote?crumb=kMlYCsQaDFr&symbols=%s`
+// const quotesURL = `https://query1.finance.yahoo.com/v6/finance/quote?symbols=%s`
+const quotesURL = `https://query2.finance.yahoo.com/v7/finance/quote?crumb=%s&symbols=%s`
+const crumbURL = "https://query1.finance.yahoo.com/v1/test/getcrumb"
+const cookieURL = "https://login.yahoo.com"
+const userAgent = "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:109.0) Gecko/20100101 Firefox/113.0"
 
 // const quotesURLv7QueryParts = `&range=1d&interval=5m&indicators=close&includeTimestamps=false&includePrePost=false&corsDomain=finance.yahoo.com&.tsrc=finance`
 const quotesURLQueryParts = `&range=1d&interval=5m&indicators=close&includeTimestamps=false&includePrePost=false&corsDomain=finance.yahoo.com&.tsrc=finance`
@@ -75,6 +72,80 @@ func NewQuotes(market *Market, profile *Profile) *Quotes {
 	}
 }
 
+func fetchCrumb(cookies string) string {
+	client := http.Client{}
+	request, err := http.NewRequest("GET", crumbURL, nil)
+	if err != nil {
+		panic(err)
+	}
+
+	request.Header = http.Header{
+		"Accept":          {"*/*"},
+		"Accept-Encoding": {"gzip, deflate, br"},
+		"Accept-Language": {"en-US,en;q=0.5"},
+		"Connection":      {"keep-alive"},
+		"Content-Type":    {"text/plain"},
+		"Cookie":          {cookies},
+		"Host":            {"query1.finance.yahoo.com"},
+		"Sec-Fetch-Dest":  {"empty"},
+		"Sec-Fetch-Mode":  {"cors"},
+		"Sec-Fetch-Site":  {"same-site"},
+		"TE":              {"trailers"},
+		"User-Agent":      {userAgent},
+	}
+
+	response, err := client.Do(request)
+	if err != nil {
+		panic(err)
+	}
+	defer response.Body.Close()
+
+	body, err := ioutil.ReadAll(response.Body)
+	if err != nil {
+		panic(err)
+	}
+
+	return string(body[:])
+}
+
+func fetchCookies() string {
+	client := http.Client{}
+	request, err := http.NewRequest("GET", cookieURL, nil)
+	if err != nil {
+		panic(err)
+	}
+
+	request.Header = http.Header{
+		"Accept":                   {"text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,*/*;q=0.8"},
+		"Accept-Encoding":          {"gzip, deflate, br"},
+		"Accept-Language":          {"en-US,en;q=0.5"},
+		"Connection":               {"keep-alive"},
+		"Host":                     {"login.yahoo.com"},
+		"Sec-Fetch-Dest":           {"document"},
+		"Sec-Fetch-Mode":           {"navigate"},
+		"Sec-Fetch-Site":           {"none"},
+		"Sec-Fetch-User":           {"?1"},
+		"TE":                       {"trailers"},
+		"Update-Insecure-Requests": {"1"},
+		"User-Agent":               {userAgent},
+	}
+
+	response, err := client.Do(request)
+	if err != nil {
+		panic(err)
+	}
+	defer response.Body.Close()
+
+	var result string
+	for _, cookie := range response.Cookies() {
+		if cookie.Name != "AS" {
+			result += cookie.Name + "=" + cookie.Value + "; "
+		}
+	}
+	result = strings.TrimSuffix(result, "; ")
+	return result
+}
+
 // Fetch the latest stock quotes and parse raw fetched data into array of
 // []Stock structs.
 func (quotes *Quotes) Fetch() (self *Quotes) {
@@ -88,7 +159,8 @@ func (quotes *Quotes) Fetch() (self *Quotes) {
 			}
 		}()
 
-		url := fmt.Sprintf(quotesURL, strings.Join(quotes.profile.Tickers, `,`))
+		cookies := fetchCookies()
+		url := fmt.Sprintf(quotesURL, fetchCrumb(cookies), strings.Join(quotes.profile.Tickers, `,`))
 
 		client := http.Client{}
 		request, err := http.NewRequest("GET", url, nil)
@@ -101,20 +173,17 @@ func (quotes *Quotes) Fetch() (self *Quotes) {
 			// TODO: handle compressed responses
 			// "Accept-Encoding": {"gzip, deflate, br"},
 			"Accept-Language": {"en-US,en;q=0.5"},
-			// "Cache-Control":   {"no-cache"},
-			"Connection":   {"keep-alive"},
-			"Content-Type": {"application/json"},
-			// TODO: Cookie appears to contain the auth key now.  Need to find out where it gets set.
-			"Cookie": {"A1=d=AQABBFB6cWQCELQ4s6JOxQKTKNPvBOFxDqUFEgEBAQHLcmR7ZNxW0iMA_eMAAA&S=AQAAAq1FEm1oxGDI_QKzTM7o4Xk; A3=d=AQABBFB6cWQCELQ4s6JOxQKTKNPvBOFxDqUFEgEBAQHLcmR7ZNxW0iMA_eMAAA&S=AQAAAq1FEm1oxGDI_QKzTM7o4Xk; A1S=d=AQABBFB6cWQCELQ4s6JOxQKTKNPvBOFxDqUFEgEBAQHLcmR7ZNxW0iMA_eMAAA&S=AQAAAq1FEm1oxGDI_QKzTM7o4Xk&j=US; PRF=t%3DAAPL%26newChartbetateaser%3D0%252C1686368084930"},
-			"Host":   {"query2.finance.yahoo.com"},
-			"Origin": {"https://finance.yahoo.com"},
-			// "Pragma":          {"no-cache"},
-			"Referer":        {"https://finance.yahoo.com/"},
-			"Sec-Fetch-Dest": {"empty"},
-			"Sec-Fetch-Mode": {"cors"},
-			"Sec-Fetch-Site": {"same-site"},
-			"TE":             {"trailers"},
-			"User-Agent":     {"Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:109.0) Gecko/20100101 Firefox/113.0"},
+			"Connection":      {"keep-alive"},
+			"Content-Type":    {"application/json"},
+			"Cookie":          {cookies},
+			"Host":            {"query2.finance.yahoo.com"},
+			"Origin":          {"https://finance.yahoo.com"},
+			"Referer":         {"https://finance.yahoo.com"},
+			"Sec-Fetch-Dest":  {"empty"},
+			"Sec-Fetch-Mode":  {"cors"},
+			"Sec-Fetch-Site":  {"same-site"},
+			"TE":              {"trailers"},
+			"User-Agent":      {userAgent},
 		}
 
 		response, err := client.Do(request)

--- a/yahoo_quotes.go
+++ b/yahoo_quotes.go
@@ -15,13 +15,7 @@ import (
 	"strings"
 )
 
-// Ongoing issue with Yahoo API version
-// const quotesURLv7 = `https://query1.finance.yahoo.com/v7/finance/quote?symbols=%s`
-// const quotesURL = `https://query1.finance.yahoo.com/v6/finance/quote?symbols=%s`
 const quotesURL = `https://query2.finance.yahoo.com/v7/finance/quote?crumb=%s&symbols=%s`
-const crumbURL = "https://query1.finance.yahoo.com/v1/test/getcrumb"
-const cookieURL = "https://login.yahoo.com"
-const userAgent = "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:109.0) Gecko/20100101 Firefox/113.0"
 
 // const quotesURLv7QueryParts = `&range=1d&interval=5m&indicators=close&includeTimestamps=false&includePrePost=false&corsDomain=finance.yahoo.com&.tsrc=finance`
 const quotesURLQueryParts = `&range=1d&interval=5m&indicators=close&includeTimestamps=false&includePrePost=false&corsDomain=finance.yahoo.com&.tsrc=finance`
@@ -72,80 +66,6 @@ func NewQuotes(market *Market, profile *Profile) *Quotes {
 	}
 }
 
-func fetchCrumb(cookies string) string {
-	client := http.Client{}
-	request, err := http.NewRequest("GET", crumbURL, nil)
-	if err != nil {
-		panic(err)
-	}
-
-	request.Header = http.Header{
-		"Accept":          {"*/*"},
-		"Accept-Encoding": {"gzip, deflate, br"},
-		"Accept-Language": {"en-US,en;q=0.5"},
-		"Connection":      {"keep-alive"},
-		"Content-Type":    {"text/plain"},
-		"Cookie":          {cookies},
-		"Host":            {"query1.finance.yahoo.com"},
-		"Sec-Fetch-Dest":  {"empty"},
-		"Sec-Fetch-Mode":  {"cors"},
-		"Sec-Fetch-Site":  {"same-site"},
-		"TE":              {"trailers"},
-		"User-Agent":      {userAgent},
-	}
-
-	response, err := client.Do(request)
-	if err != nil {
-		panic(err)
-	}
-	defer response.Body.Close()
-
-	body, err := ioutil.ReadAll(response.Body)
-	if err != nil {
-		panic(err)
-	}
-
-	return string(body[:])
-}
-
-func fetchCookies() string {
-	client := http.Client{}
-	request, err := http.NewRequest("GET", cookieURL, nil)
-	if err != nil {
-		panic(err)
-	}
-
-	request.Header = http.Header{
-		"Accept":                   {"text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,*/*;q=0.8"},
-		"Accept-Encoding":          {"gzip, deflate, br"},
-		"Accept-Language":          {"en-US,en;q=0.5"},
-		"Connection":               {"keep-alive"},
-		"Host":                     {"login.yahoo.com"},
-		"Sec-Fetch-Dest":           {"document"},
-		"Sec-Fetch-Mode":           {"navigate"},
-		"Sec-Fetch-Site":           {"none"},
-		"Sec-Fetch-User":           {"?1"},
-		"TE":                       {"trailers"},
-		"Update-Insecure-Requests": {"1"},
-		"User-Agent":               {userAgent},
-	}
-
-	response, err := client.Do(request)
-	if err != nil {
-		panic(err)
-	}
-	defer response.Body.Close()
-
-	var result string
-	for _, cookie := range response.Cookies() {
-		if cookie.Name != "AS" {
-			result += cookie.Name + "=" + cookie.Value + "; "
-		}
-	}
-	result = strings.TrimSuffix(result, "; ")
-	return result
-}
-
 // Fetch the latest stock quotes and parse raw fetched data into array of
 // []Stock structs.
 func (quotes *Quotes) Fetch() (self *Quotes) {
@@ -169,9 +89,7 @@ func (quotes *Quotes) Fetch() (self *Quotes) {
 		}
 
 		request.Header = http.Header{
-			"Accept": {"application/json"},
-			// TODO: handle compressed responses
-			// "Accept-Encoding": {"gzip, deflate, br"},
+			"Accept":          {"*/*"},
 			"Accept-Language": {"en-US,en;q=0.5"},
 			"Connection":      {"keep-alive"},
 			"Content-Type":    {"application/json"},

--- a/yahoo_quotes.go
+++ b/yahoo_quotes.go
@@ -15,7 +15,7 @@ import (
 	"strings"
 )
 
-const quotesURL = `https://query2.finance.yahoo.com/v7/finance/quote?crumb=%s&symbols=%s`
+const quotesURL = `https://query1.finance.yahoo.com/v7/finance/quote?crumb=%s&symbols=%s`
 
 // const quotesURLv7QueryParts = `&range=1d&interval=5m&indicators=close&includeTimestamps=false&includePrePost=false&corsDomain=finance.yahoo.com&.tsrc=finance`
 const quotesURLQueryParts = `&range=1d&interval=5m&indicators=close&includeTimestamps=false&includePrePost=false&corsDomain=finance.yahoo.com&.tsrc=finance`
@@ -94,7 +94,7 @@ func (quotes *Quotes) Fetch() (self *Quotes) {
 			"Connection":      {"keep-alive"},
 			"Content-Type":    {"application/json"},
 			"Cookie":          {cookies},
-			"Host":            {"query2.finance.yahoo.com"},
+			"Host":            {"query1.finance.yahoo.com"},
 			"Origin":          {"https://finance.yahoo.com"},
 			"Referer":         {"https://finance.yahoo.com"},
 			"Sec-Fetch-Dest":  {"empty"},


### PR DESCRIPTION
This fix restores previous functionality by simulating the calls a web browser makes on the yahoo finance site.