### PR TITLE
reduce default market / quotes refresh rates

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@ go build ./cmd/mop
 ```
 
 ### Using mop
+By default, Mop refreshes quotes and market data on a 5 minute (600s) interval.  These values can be changed in the .moprc file.
+
 For demonstration purposes Mop comes preconfigured with a number of stock tickers. You can easily change the default list by using the following keyboard commands:
 
     +       Add stocks to the list.

--- a/cmd/mop/main.go
+++ b/cmd/mop/main.go
@@ -21,7 +21,7 @@ import (
 // File name in user's home directory where we store the settings.
 const defaultProfile = `.moprc`
 
-const help = `Mop v1.0.0 -- Copyright (c) 2013-2022 by Michael Dvorkin. All Rights Reserved.
+const help = `Mop v1.0.0 -- Copyright (c) 2013-2023 by Michael Dvorkin and contributors. All Rights Reserved.
 NO WARRANTIES OF ANY KIND WHATSOEVER. SEE THE LICENSE FILE FOR DETAILS.
 
 <u>Command</u>    <u>Description                                </u>
@@ -43,7 +43,7 @@ Enter comma-delimited list of stock tickers when prompted.
 <r> Press any key to continue </r>
 `
 
-//-----------------------------------------------------------------------------
+// -----------------------------------------------------------------------------
 func mainLoop(screen *mop.Screen, profile *mop.Profile) {
 	var lineEditor *mop.LineEditor
 	var columnEditor *mop.ColumnEditor
@@ -54,8 +54,8 @@ func mainLoop(screen *mop.Screen, profile *mop.Profile) {
 	keyboardQueue := make(chan termbox.Event, 128)
 
 	timestampQueue := time.NewTicker(1 * time.Second)
-	quotesQueue := time.NewTicker(5 * time.Second)
-	marketQueue := time.NewTicker(12 * time.Second)
+	quotesQueue := time.NewTicker(time.Duration(profile.QuotesRefresh) * time.Second)
+	marketQueue := time.NewTicker(time.Duration(profile.MarketRefresh) * time.Second)
 	showingHelp := false
 	paused := false
 	upDownJump := profile.UpDownJump
@@ -188,7 +188,7 @@ loop:
 	}
 }
 
-//-----------------------------------------------------------------------------
+// -----------------------------------------------------------------------------
 func main() {
 	usr, err := user.Current()
 	if err != nil {

--- a/profile.go
+++ b/profile.go
@@ -103,9 +103,9 @@ func NewProfile(filename string) (*Profile, error) {
 
 // Initializes a profile with the default values
 func (profile *Profile) InitDefaultProfile() {
-	profile.MarketRefresh = 12 // Market data gets fetched every 12s (5 times per minute).
-	profile.QuotesRefresh = 5  // Stock quotes get updated every 5s (12 times per minute).
-	profile.Grouped = false    // Stock quotes are *not* grouped by advancing/declining.
+	profile.MarketRefresh = 600 // Market data gets fetched every 600s (1 time per 5 minutes).
+	profile.QuotesRefresh = 600 // Stock quotes get updated every 600s (1 time per 5 minutes).
+	profile.Grouped = false     // Stock quotes are *not* grouped by advancing/declining.
 	profile.Tickers = []string{`AAPL`, `C`, `GOOG`, `IBM`, `KO`, `ORCL`, `V`}
 	profile.SortColumn = 0   // Stock quotes are sorted by ticker name.
 	profile.Ascending = true // A to Z.


### PR DESCRIPTION
Set a slow default rate to behave like delayed quotes, which may avoid some of Yahoo's concerns.