### PR TITLE
Improve currency display logic

### DIFF
--- a/layout.go
+++ b/layout.go
@@ -17,12 +17,12 @@ import (
 )
 
 var currencies = map[string]string{
-	"RUB": "₽",
+	"EUR": "€",
 	"GBP": "£",
 	"GBp": "p",
-	"SEK": "kr",
-	"EUR": "€",
 	"JPY": "¥",
+	"RUB": "₽",
+	"USD": "$",
 }
 
 // Column describes formatting rules for individual column within the list
@@ -337,9 +337,9 @@ func currency(str ...string) string {
 	if len(str) < 2 {
 		return "ERR"
 	}
-	//default to $
-	symbol := "$"
+	// do not default to $ to avoid mislabelling other currencies as $
 	c, ok := currencies[str[1]]
+	symbol := str[1]
 	if ok {
 		symbol = c
 	}

--- a/layout.go
+++ b/layout.go
@@ -20,8 +20,12 @@ var currencies = map[string]string{
 	"EUR": "€",
 	"GBP": "£",
 	"GBp": "p",
+	"ILA": "₪",
+	"INR": "₹",
 	"JPY": "¥",
+	"KRW": "₩",
 	"RUB": "₽",
+	"TRY": "₺",
 	"USD": "$",
 }
 


### PR DESCRIPTION
Trying to fix the issue linked below.
This PR removes defaulting to USD — which just leads to any currency we don't explicitly deal with being displayed as if it were USD.
Makes it so that any currency we don't deal with explicitly to assign a shorthand symbol to is displayed via the letter code received.

Sadly three letter codes look absolutely ugly in the interface, but most currencies don't have other unambiguous shorthands.

![decohost_2025-06-20T17:41:42](https://github.com/user-attachments/assets/1e2016f9-1c8a-45cf-8222-3e1000021052)



I'm wondering whether that can be improved — but even if not I'd recommend merging this, in any event it's better than having the value misreported.



Fixes: https://github.com/mop-tracker/mop/issues/138

