### PR TITLE
Fixed dividend yield handling

### DIFF
--- a/yahoo_quotes.go
+++ b/yahoo_quotes.go
@@ -197,7 +197,15 @@ func (quotes *Quotes) parse2(body []byte) (*Quotes, error) {
 		// TODO calculate rt
 		quotes.stocks[i].PeRatioX = result["trailingPE"]
 		quotes.stocks[i].Dividend = result["trailingAnnualDividendRate"]
-		quotes.stocks[i].Yield = result["trailingAnnualDividendYield"]
+		// The value here is returned in decimal representation but we want to display it as a percentage.
+		val, err := strconv.ParseFloat(result["trailingAnnualDividendYield"], 64)
+		if err != nil {
+			// I think this might break if the case actually triggers no idea how to do it more robustly.
+			quotes.stocks[i].Yield = "N/A"
+		} else {
+			quotes.stocks[i].Yield = strconv.FormatFloat(val * 100, 'f', 2, 64)
+		}
+		//quotes.stocks[i].Yield = "100"
 		quotes.stocks[i].MarketCap = result["marketCap"]
 		// TODO calculate rt?
 		quotes.stocks[i].MarketCapX = result["marketCap"]


### PR DESCRIPTION
Dividend yields were previously underreported by a factor of 100.
This is because the yahoo API returns the values as a decimal fraction, but we listed them as percentages.

Before
![decohost_2025-06-21T07:28:00](https://github.com/user-attachments/assets/2f96f692-62b9-4ef6-8026-7110233ff46b)


After
![decohost_2025-06-21T07:27:40](https://github.com/user-attachments/assets/cc7ef3ed-bd46-4db5-bc29-5b59fa09cbb8)
