### PR TITLE
Feat/add golangci lint formatter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,28 @@
+# See for configurations: https://golangci-lint.run/usage/configuration/
+version: 2
+
+# See: https://golangci-lint.run/usage/formatters/
+formatters:
+  default: none
+  enable:
+    - gci # https://github.com/daixiang0/gci
+    - gofmt # https://pkg.go.dev/cmd/gofmt
+    - gofumpt # https://github.com/mvdan/gofumpt
+    - goimports # https://pkg.go.dev/golang.org/x/tools/cmd/goimports
+
+  settings:
+    gci:
+      sections:
+        - standard
+        - default
+        - localmodule
+    gofmt:
+      simplify: true # Simplify code: gofmt with `-s` option.
+
+    gofumpt:
+      # Module path which contains the source code being formatted.
+      # Default: ""
+      module-path: github.com/mop-tracker/mop # Should match with module in go.mod
+      # Choose whether to use the extra rules.
+      # Default: false
+      extra-rules: true

--- a/cmd/mop/main.go
+++ b/cmd/mop/main.go
@@ -14,8 +14,9 @@ import (
 	"time"
 
 	"github.com/eiannone/keyboard"
-	"github.com/mop-tracker/mop"
 	"github.com/nsf/termbox-go"
+
+	"github.com/mop-tracker/mop"
 )
 
 // File name in user's home directory where we store the settings.
@@ -147,12 +148,12 @@ loop:
 			case termbox.EventResize:
 				screen.Resize()
 				if !showingHelp {
-					//screen.Draw(market)
-					//redrawQuotesFlag = true
-					//screen.Draw(market)
+					// screen.Draw(market)
+					// redrawQuotesFlag = true
+					// screen.Draw(market)
 					redrawQuotesFlag = true
 					redrawMarketFlag = true
-					//screen.DrawOldQuotes(quotes)
+					// screen.DrawOldQuotes(quotes)
 				} else {
 					screen.Draw(help)
 				}

--- a/column_editor.go
+++ b/column_editor.go
@@ -4,7 +4,7 @@
 
 package mop
 
-import `github.com/nsf/termbox-go`
+import "github.com/nsf/termbox-go"
 
 // ColumnEditor handles column sort order. When activated it highlights
 // current column name in the header, then waits for arrow keys (choose
@@ -53,14 +53,14 @@ func (editor *ColumnEditor) Handle(event termbox.Event) bool {
 	return false
 }
 
-//-----------------------------------------------------------------------------
+// -----------------------------------------------------------------------------
 func (editor *ColumnEditor) selectCurrentColumn() *ColumnEditor {
 	editor.profile.selectedColumn = editor.profile.SortColumn
 	editor.redrawHeader()
 	return editor
 }
 
-//-----------------------------------------------------------------------------
+// -----------------------------------------------------------------------------
 func (editor *ColumnEditor) selectLeftColumn() *ColumnEditor {
 	editor.profile.selectedColumn--
 	if editor.profile.selectedColumn < 0 {
@@ -69,7 +69,7 @@ func (editor *ColumnEditor) selectLeftColumn() *ColumnEditor {
 	return editor
 }
 
-//-----------------------------------------------------------------------------
+// -----------------------------------------------------------------------------
 func (editor *ColumnEditor) selectRightColumn() *ColumnEditor {
 	editor.profile.selectedColumn++
 	if editor.profile.selectedColumn > editor.layout.TotalColumns()-1 {
@@ -78,7 +78,7 @@ func (editor *ColumnEditor) selectRightColumn() *ColumnEditor {
 	return editor
 }
 
-//-----------------------------------------------------------------------------
+// -----------------------------------------------------------------------------
 func (editor *ColumnEditor) execute() *ColumnEditor {
 	if editor.profile.Reorder() == nil {
 		editor.screen.Draw(editor.quotes)
@@ -87,13 +87,13 @@ func (editor *ColumnEditor) execute() *ColumnEditor {
 	return editor
 }
 
-//-----------------------------------------------------------------------------
+// -----------------------------------------------------------------------------
 func (editor *ColumnEditor) done() bool {
 	editor.profile.selectedColumn = -1
 	return true
 }
 
-//-----------------------------------------------------------------------------
+// -----------------------------------------------------------------------------
 func (editor *ColumnEditor) redrawHeader() {
 	editor.screen.DrawLine(0, 4, editor.layout.Header(editor.profile))
 	termbox.Flush()

--- a/filter.go
+++ b/filter.go
@@ -5,8 +5,8 @@
 package mop
 
 import (
-	"strings"
 	"strconv"
+	"strings"
 )
 
 // Filter gets called to sort stock quotes by one of the columns. The
@@ -24,16 +24,16 @@ func NewFilter(profile *Profile) *Filter {
 }
 
 // Changes money and % notation to a plain float for math, comparisons.
-func stringToNumber (numberString string) float64 {
+func stringToNumber(numberString string) float64 {
 	// If the string "$3.6B" is passed in, the returned float will be 3.6E+09.
 	// If 0.03% is passed in, the returned float will be 0.03 (NOT 0.0003!).
-	newString := strings.TrimSpace(numberString) // Take off whitespace.
-	newString = strings.Replace(newString,"$","",1)      // Remove the $ symbol.
-	newString = strings.Replace(newString,"%","",1)      // Remove the $ symbol.
-	newString = strings.Replace(newString,"K","E+3",1)   // Thousand (kilo)
-	newString = strings.Replace(newString,"M","E+6",1)   // Million
-	newString = strings.Replace(newString,"B","E+9",1)   // Billion
-	newString = strings.Replace(newString,"T","E+12",1)  // Trillion
+	newString := strings.TrimSpace(numberString)           // Take off whitespace.
+	newString = strings.Replace(newString, "$", "", 1)     // Remove the $ symbol.
+	newString = strings.Replace(newString, "%", "", 1)     // Remove the $ symbol.
+	newString = strings.Replace(newString, "K", "E+3", 1)  // Thousand (kilo)
+	newString = strings.Replace(newString, "M", "E+6", 1)  // Million
+	newString = strings.Replace(newString, "B", "E+9", 1)  // Billion
+	newString = strings.Replace(newString, "T", "E+12", 1) // Trillion
 	finalValue, _ := strconv.ParseFloat(newString, 64)
 	return finalValue
 }
@@ -44,45 +44,44 @@ func (filter *Filter) Apply(stocks []Stock) []Stock {
 	var filteredStocks []Stock
 
 	for _, stock := range stocks {
-		var values = make(map[string]interface{})
+		values := make(map[string]interface{})
 		// Make conversions from the strings to floats where necessary.
-		values["ticker"]        = strings.TrimSpace(stock.Ticker) // Remains string
-		values["last"]          = stringToNumber(stock.LastTrade)
-		values["change"]        = stringToNumber(stock.Change)
+		values["ticker"] = strings.TrimSpace(stock.Ticker) // Remains string
+		values["last"] = stringToNumber(stock.LastTrade)
+		values["change"] = stringToNumber(stock.Change)
 		values["changePercent"] = stringToNumber(stock.ChangePct)
-		values["open"]          = stringToNumber(stock.Open)
-		values["low"]           = stringToNumber(stock.Low)
-		values["high"]          = stringToNumber(stock.High)
-		values["low52"]         = stringToNumber(stock.Low52)
-		values["high52"]        = stringToNumber(stock.High52)
-		values["dividend"]      = stringToNumber(stock.Dividend)
-		values["yield"]         = stringToNumber(stock.Yield)
-		values["mktCap"]        = stringToNumber(stock.MarketCap)
-		values["mktCapX"]       = stringToNumber(stock.MarketCapX)
-		values["volume"]        = stringToNumber(stock.Volume)
-		values["avgVolume"]     = stringToNumber(stock.AvgVolume)
-		values["pe"]            = stringToNumber(stock.PeRatio)
-		values["peX"]           = stringToNumber(stock.PeRatioX)
-		values["direction"]     = stock.Direction                 // Remains int.
+		values["open"] = stringToNumber(stock.Open)
+		values["low"] = stringToNumber(stock.Low)
+		values["high"] = stringToNumber(stock.High)
+		values["low52"] = stringToNumber(stock.Low52)
+		values["high52"] = stringToNumber(stock.High52)
+		values["dividend"] = stringToNumber(stock.Dividend)
+		values["yield"] = stringToNumber(stock.Yield)
+		values["mktCap"] = stringToNumber(stock.MarketCap)
+		values["mktCapX"] = stringToNumber(stock.MarketCapX)
+		values["volume"] = stringToNumber(stock.Volume)
+		values["avgVolume"] = stringToNumber(stock.AvgVolume)
+		values["pe"] = stringToNumber(stock.PeRatio)
+		values["peX"] = stringToNumber(stock.PeRatioX)
+		values["direction"] = stock.Direction // Remains int.
 
 		result, err := filter.profile.filterExpression.Evaluate(values)
-
 		if err != nil {
-                        // The filter isn't working, so reset to no filter.
-                        filter.profile.Filter = ""
-                        // Return an empty list.  The next main loop cycle will
-                        // show unfiltered.
-                        return filteredStocks
+			// The filter isn't working, so reset to no filter.
+			filter.profile.Filter = ""
+			// Return an empty list.  The next main loop cycle will
+			// show unfiltered.
+			return filteredStocks
 		}
 
 		truthy, ok := result.(bool)
 
 		if !ok {
-                        // The filter isn't working, so reset to no filter.
-                        filter.profile.Filter = ""
-                        // Return an empty list.  The next main loop cycle will
-                        // show unfiltered.
-                        return filteredStocks
+			// The filter isn't working, so reset to no filter.
+			filter.profile.Filter = ""
+			// Return an empty list.  The next main loop cycle will
+			// show unfiltered.
+			return filteredStocks
 		}
 
 		if truthy {

--- a/layout.go
+++ b/layout.go
@@ -337,7 +337,7 @@ func currency(str ...string) string {
 	if len(str) < 2 {
 		return "ERR"
 	}
-	//default to $
+	// default to $
 	symbol := "$"
 	c, ok := currencies[str[1]]
 	if ok {

--- a/line_editor.go
+++ b/line_editor.go
@@ -102,7 +102,7 @@ func (editor *LineEditor) Handle(ev termbox.Event) bool {
 	return false
 }
 
-//-----------------------------------------------------------------------------
+// -----------------------------------------------------------------------------
 func (editor *LineEditor) deletePreviousCharacter() *LineEditor {
 	if editor.cursor > 0 {
 		if editor.cursor < len(editor.input) {
@@ -119,7 +119,7 @@ func (editor *LineEditor) deletePreviousCharacter() *LineEditor {
 	return editor
 }
 
-//-----------------------------------------------------------------------------
+// -----------------------------------------------------------------------------
 func (editor *LineEditor) insertCharacter(ch rune) *LineEditor {
 	if editor.cursor < len(editor.input) {
 		// Insert the character in the middle of the input string.
@@ -134,7 +134,7 @@ func (editor *LineEditor) insertCharacter(ch rune) *LineEditor {
 	return editor
 }
 
-//-----------------------------------------------------------------------------
+// -----------------------------------------------------------------------------
 func (editor *LineEditor) moveLeft() *LineEditor {
 	if editor.cursor > 0 {
 		editor.cursor--
@@ -144,7 +144,7 @@ func (editor *LineEditor) moveLeft() *LineEditor {
 	return editor
 }
 
-//-----------------------------------------------------------------------------
+// -----------------------------------------------------------------------------
 func (editor *LineEditor) moveRight() *LineEditor {
 	if editor.cursor < len(editor.input) {
 		editor.cursor++
@@ -154,7 +154,7 @@ func (editor *LineEditor) moveRight() *LineEditor {
 	return editor
 }
 
-//-----------------------------------------------------------------------------
+// -----------------------------------------------------------------------------
 func (editor *LineEditor) jumpToBeginning() *LineEditor {
 	editor.cursor = 0
 	termbox.SetCursor(len(editor.prompt)+editor.cursor, 3)
@@ -162,7 +162,7 @@ func (editor *LineEditor) jumpToBeginning() *LineEditor {
 	return editor
 }
 
-//-----------------------------------------------------------------------------
+// -----------------------------------------------------------------------------
 func (editor *LineEditor) jumpToEnd() *LineEditor {
 	editor.cursor = len(editor.input)
 	termbox.SetCursor(len(editor.prompt)+editor.cursor, 3)
@@ -170,7 +170,7 @@ func (editor *LineEditor) jumpToEnd() *LineEditor {
 	return editor
 }
 
-//-----------------------------------------------------------------------------
+// -----------------------------------------------------------------------------
 func (editor *LineEditor) execute() *LineEditor {
 	switch editor.command {
 	case '+':
@@ -207,7 +207,7 @@ func (editor *LineEditor) execute() *LineEditor {
 	return editor
 }
 
-//-----------------------------------------------------------------------------
+// -----------------------------------------------------------------------------
 func (editor *LineEditor) done() bool {
 	editor.screen.ClearLine(0, 3)
 	termbox.HideCursor()

--- a/markup.go
+++ b/markup.go
@@ -27,7 +27,7 @@ import (
 type Markup struct {
 	Foreground   termbox.Attribute            // Foreground color.
 	Background   termbox.Attribute            // Background color (so far always termbox.ColorDefault).
-        RowShading   termbox.Attribute            // Background color for Row Shading.
+	RowShading   termbox.Attribute            // Background color for Row Shading.
 	RightAligned bool                         // True when the string is right aligned.
 	tags         map[string]termbox.Attribute // Tags to Termbox translation hash.
 	regex        *regexp.Regexp               // Regex to identify the supported tag names.
@@ -75,7 +75,7 @@ func NewMarkup(profile *Profile) *Markup {
 	markup.Background = termbox.ColorDefault
 	markup.RightAligned = false
 
-        markup.RowShading = markup.tags[profile.Colors.RowShading]
+	markup.RowShading = markup.tags[profile.Colors.RowShading]
 
 	markup.regex = markup.supportedTags() // Once we have the hash we could build the regex.
 
@@ -86,12 +86,11 @@ func NewMarkup(profile *Profile) *Markup {
 // the delimiters. For example, the "<green>Hello, <red>world!</>" string when
 // tokenized by tags produces the following:
 //
-//   [0] "<green>"
-//   [1] "Hello, "
-//   [2] "<red>"
-//   [3] "world!"
-//   [4] "</>"
-//
+//	[0] "<green>"
+//	[1] "Hello, "
+//	[2] "<red>"
+//	[3] "world!"
+//	[4] "</>"
 func (markup *Markup) Tokenize(str string) []string {
 	matches := markup.regex.FindAllStringIndex(str, -1)
 	strings := make([]string, 0, len(matches))
@@ -130,7 +129,7 @@ func (markup *Markup) IsTag(str string) bool {
 	return markup.process(tag, open)
 }
 
-//-----------------------------------------------------------------------------
+// -----------------------------------------------------------------------------
 func (markup *Markup) process(tag string, open bool) bool {
 	if attribute, ok := markup.tags[tag]; ok {
 		switch tag {
@@ -168,7 +167,7 @@ func (markup *Markup) supportedTags() *regexp.Regexp {
 	return regexp.MustCompile(strings.Join(arr, `|`))
 }
 
-//-----------------------------------------------------------------------------
+// -----------------------------------------------------------------------------
 func probeForTag(str string) (string, bool) {
 	if len(str) > 2 && str[0:1] == `<` && str[len(str)-1:] == `>` {
 		return extractTagName(str), str[1:2] != `/`

--- a/profile.go
+++ b/profile.go
@@ -13,12 +13,14 @@ import (
 	"github.com/Knetic/govaluate"
 )
 
-const defaultGainColor = "green"
-const defaultLossColor = "red"
-const defaultTagColor = "yellow"
-const defaultHeaderColor = "lightgray"
-const defaultTimeColor = "lightgray"
-const defaultColor = "lightgray"
+const (
+	defaultGainColor   = "green"
+	defaultLossColor   = "red"
+	defaultTagColor    = "yellow"
+	defaultHeaderColor = "lightgray"
+	defaultTimeColor   = "lightgray"
+	defaultColor       = "lightgray"
+)
 
 // Profile manages Mop program settings as defined by user (ex. list of
 // stock tickers). The settings are serialized using JSON and saved in
@@ -32,15 +34,15 @@ type Profile struct {
 	Grouped       bool     // True when stocks are grouped by advancing/declining.
 	Filter        string   // Filter in human form
 	UpDownJump    int      // Number of lines to go up/down when scrolling.
-        RowShading    bool     // Should alternate rows be shaded?
+	RowShading    bool     // Should alternate rows be shaded?
 	Colors        struct { // User defined colors
-		Gain    string
-		Loss    string
-		Tag     string
-		Header  string
-		Time    string
-		Default string
-                RowShading  string
+		Gain       string
+		Loss       string
+		Tag        string
+		Header     string
+		Time       string
+		Default    string
+		RowShading string
 	}
 	ShowTimestamp    bool                           // Show or hide current time in the top right of the screen
 	filterExpression *govaluate.EvaluableExpression // The filter as a govaluate expression
@@ -88,7 +90,7 @@ func NewProfile(filename string) (*Profile, error) {
 			InitColor(&profile.Colors.Header, defaultHeaderColor)
 			InitColor(&profile.Colors.Time, defaultTimeColor)
 			InitColor(&profile.Colors.Default, defaultColor)
-                        InitColor(&profile.Colors.RowShading, defaultColor)
+			InitColor(&profile.Colors.RowShading, defaultColor)
 
 			profile.SetFilter(profile.Filter)
 		}
@@ -121,8 +123,8 @@ func (profile *Profile) InitDefaultProfile() {
 	profile.Colors.Header = defaultHeaderColor
 	profile.Colors.Time = defaultTimeColor
 	profile.Colors.Default = defaultColor
-        profile.Colors.RowShading = defaultColor
-        profile.RowShading = false
+	profile.Colors.RowShading = defaultColor
+	profile.RowShading = false
 	profile.ShowTimestamp = false
 	profile.Save()
 }
@@ -143,7 +145,7 @@ func (profile *Profile) Save() error {
 		return err
 	}
 
-	return ioutil.WriteFile(profile.filename, data, 0644)
+	return ioutil.WriteFile(profile.filename, data, 0o644)
 }
 
 // AddTickers updates the list of existing tickers to add the new ones making
@@ -217,7 +219,6 @@ func (profile *Profile) SetFilter(filter string) {
 	if len(filter) > 0 {
 		var err error
 		profile.filterExpression, err = govaluate.NewEvaluableExpression(filter)
-
 		if err != nil {
 			panic(err)
 		}

--- a/screen.go
+++ b/screen.go
@@ -22,7 +22,7 @@ type Screen struct {
 	layout     *Layout    // Pointer to layout (gets created by screen).
 	markup     *Markup    // Pointer to markup processor (gets created by screen).
 	pausedAt   *time.Time // Timestamp of the pause request or nil if none.
-        profile    *Profile   // Pointer to profile passed to NewScreen
+	profile    *Profile   // Pointer to profile passed to NewScreen
 	offset     int        // Offset for scrolling
 	headerLine int        // Line number of header for scroll feature
 	max        int        // highest offset
@@ -38,7 +38,7 @@ func NewScreen(profile *Profile) *Screen {
 	screen := &Screen{}
 	screen.layout = NewLayout()
 	screen.markup = NewMarkup(profile)
-        screen.profile = profile
+	screen.profile = profile
 	screen.offset = 0
 
 	return screen.Resize()
@@ -83,7 +83,7 @@ func (screen *Screen) Clear() *Screen {
 
 // ClearLine erases the contents of the line starting from (x,y) coordinate
 // till the end of the line.
-func (screen *Screen) ClearLine(x int, y int) *Screen {
+func (screen *Screen) ClearLine(x, y int) *Screen {
 	for i := x; i < screen.width; i++ {
 		termbox.SetCell(i, y, ' ', termbox.ColorDefault, termbox.ColorDefault)
 	}
@@ -165,15 +165,15 @@ func (screen *Screen) Draw(objects ...interface{}) *Screen {
 // DrawLineFlush gives the option to flush screen after drawing
 
 // wrapper for DrawLineFlush
-func (screen *Screen) DrawLine(x int, y int, str string) {
+func (screen *Screen) DrawLine(x, y int, str string) {
 	screen.DrawLineFlush(x, y, str, true)
 }
 
-func (screen *Screen) DrawLineInverted(x int, y int, str string) {
+func (screen *Screen) DrawLineInverted(x, y int, str string) {
 	screen.DrawLineFlushInverted(x, y, str, true)
 }
 
-func (screen *Screen) DrawLineFlush(x int, y int, str string, flush bool) {
+func (screen *Screen) DrawLineFlush(x, y int, str string, flush bool) {
 	start, column := 0, 0
 
 	for _, token := range screen.markup.Tokenize(str) {
@@ -190,28 +190,28 @@ func (screen *Screen) DrawLineFlush(x int, y int, str string, flush bool) {
 			} else {
 				start = screen.width - len(token) + i
 			}
-                        if y % 2 == 0  && y > 4 && screen.profile.RowShading {
-                                termbox.SetCell(start, y, char, screen.markup.Foreground, screen.markup.RowShading)
-                        } else {
-                                termbox.SetCell(start, y, char, screen.markup.Foreground, screen.markup.Background)
-                        }
+			if y%2 == 0 && y > 4 && screen.profile.RowShading {
+				termbox.SetCell(start, y, char, screen.markup.Foreground, screen.markup.RowShading)
+			} else {
+				termbox.SetCell(start, y, char, screen.markup.Foreground, screen.markup.Background)
+			}
 
 		}
-                if screen.profile.RowShading {
-                if start < screen.width && y % 2 == 0 && y > 4 {
-                        for i := start ; i < screen.width; i++ {
-                                start ++;
-                                termbox.SetCell(start, y, ' ', termbox.ColorDefault, screen.markup.RowShading);
-                        }
-                }
-                }
+		if screen.profile.RowShading {
+			if start < screen.width && y%2 == 0 && y > 4 {
+				for i := start; i < screen.width; i++ {
+					start++
+					termbox.SetCell(start, y, ' ', termbox.ColorDefault, screen.markup.RowShading)
+				}
+			}
+		}
 	}
 	if flush {
 		termbox.Flush()
 	}
 }
 
-func (screen *Screen) DrawLineFlushInverted(x int, y int, str string, flush bool) {
+func (screen *Screen) DrawLineFlushInverted(x, y int, str string, flush bool) {
 	start, column := 0, 0
 
 	for _, token := range screen.markup.Tokenize(str) {
@@ -228,7 +228,7 @@ func (screen *Screen) DrawLineFlushInverted(x int, y int, str string, flush bool
 			} else {
 				start = screen.width - len(token) + i
 			}
-                        termbox.SetCell(start, y, char, screen.markup.tags[`black`], screen.markup.Foreground)
+			termbox.SetCell(start, y, char, screen.markup.tags[`black`], screen.markup.Foreground)
 		}
 	}
 	if flush {

--- a/sorter.go
+++ b/sorter.go
@@ -5,9 +5,9 @@
 package mop
 
 import (
-	`sort`
-	`strconv`
-	`strings`
+	"sort"
+	"strconv"
+	"strings"
 )
 
 // Sorter gets called to sort stock quotes by one of the columns. The
@@ -22,143 +22,178 @@ type sortable []Stock
 func (list sortable) Len() int      { return len(list) }
 func (list sortable) Swap(i, j int) { list[i], list[j] = list[j], list[i] }
 
-type byTickerAsc struct{ sortable }
-type byLastTradeAsc struct{ sortable }
-type byChangeAsc struct{ sortable }
-type byChangePctAsc struct{ sortable }
-type byOpenAsc struct{ sortable }
-type byLowAsc struct{ sortable }
-type byHighAsc struct{ sortable }
-type byLow52Asc struct{ sortable }
-type byHigh52Asc struct{ sortable }
-type byVolumeAsc struct{ sortable }
-type byAvgVolumeAsc struct{ sortable }
-type byPeRatioAsc struct{ sortable }
-type byDividendAsc struct{ sortable }
-type byYieldAsc struct{ sortable }
-type byMarketCapAsc struct{ sortable }
-type byPreOpenAsc struct{ sortable }
-type byAfterHoursAsc struct{ sortable }
+type (
+	byTickerAsc     struct{ sortable }
+	byLastTradeAsc  struct{ sortable }
+	byChangeAsc     struct{ sortable }
+	byChangePctAsc  struct{ sortable }
+	byOpenAsc       struct{ sortable }
+	byLowAsc        struct{ sortable }
+	byHighAsc       struct{ sortable }
+	byLow52Asc      struct{ sortable }
+	byHigh52Asc     struct{ sortable }
+	byVolumeAsc     struct{ sortable }
+	byAvgVolumeAsc  struct{ sortable }
+	byPeRatioAsc    struct{ sortable }
+	byDividendAsc   struct{ sortable }
+	byYieldAsc      struct{ sortable }
+	byMarketCapAsc  struct{ sortable }
+	byPreOpenAsc    struct{ sortable }
+	byAfterHoursAsc struct{ sortable }
+)
 
-type byTickerDesc struct{ sortable }
-type byLastTradeDesc struct{ sortable }
-type byChangeDesc struct{ sortable }
-type byChangePctDesc struct{ sortable }
-type byOpenDesc struct{ sortable }
-type byLowDesc struct{ sortable }
-type byHighDesc struct{ sortable }
-type byLow52Desc struct{ sortable }
-type byHigh52Desc struct{ sortable }
-type byVolumeDesc struct{ sortable }
-type byAvgVolumeDesc struct{ sortable }
-type byPeRatioDesc struct{ sortable }
-type byDividendDesc struct{ sortable }
-type byYieldDesc struct{ sortable }
-type byMarketCapDesc struct{ sortable }
-type byPreOpenDesc struct{ sortable }
-type byAfterHoursDesc struct{ sortable }
+type (
+	byTickerDesc     struct{ sortable }
+	byLastTradeDesc  struct{ sortable }
+	byChangeDesc     struct{ sortable }
+	byChangePctDesc  struct{ sortable }
+	byOpenDesc       struct{ sortable }
+	byLowDesc        struct{ sortable }
+	byHighDesc       struct{ sortable }
+	byLow52Desc      struct{ sortable }
+	byHigh52Desc     struct{ sortable }
+	byVolumeDesc     struct{ sortable }
+	byAvgVolumeDesc  struct{ sortable }
+	byPeRatioDesc    struct{ sortable }
+	byDividendDesc   struct{ sortable }
+	byYieldDesc      struct{ sortable }
+	byMarketCapDesc  struct{ sortable }
+	byPreOpenDesc    struct{ sortable }
+	byAfterHoursDesc struct{ sortable }
+)
 
 func (list byTickerAsc) Less(i, j int) bool {
 	return list.sortable[i].Ticker < list.sortable[j].Ticker
 }
+
 func (list byLastTradeAsc) Less(i, j int) bool {
 	return list.sortable[i].LastTrade < list.sortable[j].LastTrade
 }
+
 func (list byChangeAsc) Less(i, j int) bool {
 	return c(list.sortable[i].Change) < c(list.sortable[j].Change)
 }
+
 func (list byChangePctAsc) Less(i, j int) bool {
 	return c(list.sortable[i].ChangePct) < c(list.sortable[j].ChangePct)
 }
+
 func (list byOpenAsc) Less(i, j int) bool {
 	return list.sortable[i].Open < list.sortable[j].Open
 }
-func (list byLowAsc) Less(i, j int) bool { 
+
+func (list byLowAsc) Less(i, j int) bool {
 	return list.sortable[i].Low < list.sortable[j].Low
 }
+
 func (list byHighAsc) Less(i, j int) bool {
 	return list.sortable[i].High < list.sortable[j].High
 }
+
 func (list byLow52Asc) Less(i, j int) bool {
 	return list.sortable[i].Low52 < list.sortable[j].Low52
 }
+
 func (list byHigh52Asc) Less(i, j int) bool {
 	return list.sortable[i].High52 < list.sortable[j].High52
 }
+
 func (list byVolumeAsc) Less(i, j int) bool {
 	return m(list.sortable[i].Volume) < m(list.sortable[j].Volume)
 }
+
 func (list byAvgVolumeAsc) Less(i, j int) bool {
 	return m(list.sortable[i].AvgVolume) < m(list.sortable[j].AvgVolume)
 }
+
 func (list byPeRatioAsc) Less(i, j int) bool {
 	return list.sortable[i].PeRatio < list.sortable[j].PeRatio
 }
+
 func (list byDividendAsc) Less(i, j int) bool {
 	return list.sortable[i].Dividend < list.sortable[j].Dividend
 }
+
 func (list byYieldAsc) Less(i, j int) bool {
 	return list.sortable[i].Yield < list.sortable[j].Yield
 }
+
 func (list byMarketCapAsc) Less(i, j int) bool {
 	return m(list.sortable[i].MarketCap) < m(list.sortable[j].MarketCap)
 }
+
 func (list byPreOpenAsc) Less(i, j int) bool {
 	return c(list.sortable[i].PreOpen) < c(list.sortable[j].PreOpen)
 }
+
 func (list byAfterHoursAsc) Less(i, j int) bool {
 	return c(list.sortable[i].AfterHours) < c(list.sortable[j].AfterHours)
 }
 
-
 func (list byTickerDesc) Less(i, j int) bool {
 	return list.sortable[j].Ticker < list.sortable[i].Ticker
 }
+
 func (list byLastTradeDesc) Less(i, j int) bool {
 	return list.sortable[j].LastTrade < list.sortable[i].LastTrade
 }
+
 func (list byChangeDesc) Less(i, j int) bool {
 	return c(list.sortable[j].Change) < c(list.sortable[i].Change)
 }
+
 func (list byChangePctDesc) Less(i, j int) bool {
 	return c(list.sortable[j].ChangePct) < c(list.sortable[i].ChangePct)
 }
+
 func (list byOpenDesc) Less(i, j int) bool {
 	return list.sortable[j].Open < list.sortable[i].Open
 }
-func (list byLowDesc) Less(i, j int) bool { 
+
+func (list byLowDesc) Less(i, j int) bool {
 	return list.sortable[j].Low < list.sortable[i].Low
 }
+
 func (list byHighDesc) Less(i, j int) bool {
 	return list.sortable[j].High < list.sortable[i].High
 }
+
 func (list byLow52Desc) Less(i, j int) bool {
 	return list.sortable[j].Low52 < list.sortable[i].Low52
 }
+
 func (list byHigh52Desc) Less(i, j int) bool {
 	return list.sortable[j].High52 < list.sortable[i].High52
 }
+
 func (list byVolumeDesc) Less(i, j int) bool {
 	return m(list.sortable[j].Volume) < m(list.sortable[i].Volume)
 }
+
 func (list byAvgVolumeDesc) Less(i, j int) bool {
 	return m(list.sortable[j].AvgVolume) < m(list.sortable[i].AvgVolume)
 }
+
 func (list byPeRatioDesc) Less(i, j int) bool {
 	return list.sortable[j].PeRatio < list.sortable[i].PeRatio
 }
+
 func (list byDividendDesc) Less(i, j int) bool {
 	return list.sortable[j].Dividend < list.sortable[i].Dividend
 }
+
 func (list byYieldDesc) Less(i, j int) bool {
 	return list.sortable[j].Yield < list.sortable[i].Yield
 }
+
 func (list byMarketCapDesc) Less(i, j int) bool {
 	return m(list.sortable[j].MarketCap) < m(list.sortable[i].MarketCap)
 }
+
 func (list byPreOpenDesc) Less(i, j int) bool {
 	return c(list.sortable[j].PreOpen) < c(list.sortable[i].PreOpen)
 }
+
 func (list byAfterHoursDesc) Less(i, j int) bool {
 	return c(list.sortable[j].AfterHours) < c(list.sortable[i].AfterHours)
 }
@@ -227,7 +262,7 @@ func (sorter *Sorter) SortByCurrentColumn(stocks []Stock) *Sorter {
 func c(str string) float32 {
 	c := "$"
 	for _, v := range currencies {
-		if strings.Contains(str,v) {
+		if strings.Contains(str, v) {
 			c = v
 		}
 	}

--- a/yahoo_crumb.go
+++ b/yahoo_crumb.go
@@ -13,10 +13,12 @@ import (
 	"strings"
 )
 
-const crumbURL = "https://query1.finance.yahoo.com/v1/test/getcrumb"
-const cookieURL = "https://finance.yahoo.com/"
-const userAgent = "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:109.0) Gecko/20100101 Firefox/113.0"
-const euConsentURL = "https://consent.yahoo.com/v2/collectConsent?sessionId="
+const (
+	crumbURL     = "https://query1.finance.yahoo.com/v1/test/getcrumb"
+	cookieURL    = "https://finance.yahoo.com/"
+	userAgent    = "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:109.0) Gecko/20100101 Firefox/113.0"
+	euConsentURL = "https://consent.yahoo.com/v2/collectConsent?sessionId="
+)
 
 func fetchCrumb(cookies string) string {
 	client := http.Client{}
@@ -55,7 +57,6 @@ func fetchCrumb(cookies string) string {
 }
 
 func fetchCookies() string {
-
 	client := http.Client{}
 	var cookies []*http.Cookie
 

--- a/yahoo_market.go
+++ b/yahoo_market.go
@@ -11,8 +11,10 @@ import (
 	"net/http"
 )
 
-const marketURL = `https://query1.finance.yahoo.com/v7/finance/quote?crumb=%s&symbols=%s`
-const marketURLQueryParts = `&range=1d&interval=5m&indicators=close&includeTimestamps=false&includePrePost=false&corsDomain=finance.yahoo.com&.tsrc=finance`
+const (
+	marketURL           = `https://query1.finance.yahoo.com/v7/finance/quote?crumb=%s&symbols=%s`
+	marketURLQueryParts = `&range=1d&interval=5m&indicators=close&includeTimestamps=false&includePrePost=false&corsDomain=finance.yahoo.com&.tsrc=finance`
+)
 
 // Market stores current market information displayed in the top three lines of
 // the screen. The market data is fetched and parsed from the HTML page above.

--- a/yahoo_quotes.go
+++ b/yahoo_quotes.go
@@ -180,7 +180,6 @@ func (quotes *Quotes) parse2(body []byte) (*Quotes, error) {
 			default:
 				result[k] = fmt.Sprintf("%v", v)
 			}
-
 		}
 		quotes.stocks[i].Ticker = result["symbol"]
 		quotes.stocks[i].LastTrade = result["regularMarketPrice"]
@@ -203,9 +202,9 @@ func (quotes *Quotes) parse2(body []byte) (*Quotes, error) {
 			// I think this might break if the case actually triggers no idea how to do it more robustly.
 			quotes.stocks[i].Yield = "N/A"
 		} else {
-			quotes.stocks[i].Yield = strconv.FormatFloat(val * 100, 'f', 2, 64)
+			quotes.stocks[i].Yield = strconv.FormatFloat(val*100, 'f', 2, 64)
 		}
-		//quotes.stocks[i].Yield = "100"
+		// quotes.stocks[i].Yield = "100"
 		quotes.stocks[i].MarketCap = result["marketCap"]
 		// TODO calculate rt?
 		quotes.stocks[i].MarketCapX = result["marketCap"]


### PR DESCRIPTION
# Add golangci-lint formatter configuration and format codebase

## Added .golangci.yml
 - Comprehensive golangci-lint configuration file
 - Configured multiple formatters for consistent code styling
 - Set up proper module path configuration

## 🎨 Code Formatting
- Applied formatting to all Go source files using the new configuration
- Standardised import organisation and grouping

## Imrovement Notes

- In order to keep PRs small, I have introduced formatting only in this PR,
- In the next PR, I will add the linters and then lint the code.
- This PR is step1 towards the issue: #142 