### PR TITLE
Chore: Stop tickers in mainLoop

### DIFF
--- a/cmd/mop/main.go
+++ b/cmd/mop/main.go
@@ -67,6 +67,12 @@ func mainLoop(screen *mop.Screen, profile *mop.Profile) {
 	redrawQuotesFlag := false
 	redrawMarketFlag := false
 
+	defer func() {
+		timestampQueue.Stop()
+		quotesQueue.Stop()
+		marketQueue.Stop()
+	}()
+
 	go func() {
 		for {
 			keyboardQueue <- termbox.PollEvent()


### PR DESCRIPTION
Hi, I noticed that the tickers created in mainLoop aren't explicitly stopped.

This PR adds a defer `ticker.Stop()` call for each of them. 

While it's not a functional bug, it's generally good practice in Go to clean up resources.