### PR TITLE
use structs instead of maps; cleanup

### DIFF
--- a/layout.go
+++ b/layout.go
@@ -238,9 +238,9 @@ func (layout *Layout) pad(str string, width int) string {
 
 // -----------------------------------------------------------------------------
 func buildMarketTemplate() *template.Template {
-	markup := `<tag>Dow</> {{.Dow.change}} ({{.Dow.percent}}) at {{.Dow.latest}} <tag>S&P 500</> {{.Sp500.change}} ({{.Sp500.percent}}) at {{.Sp500.latest}} <tag>NASDAQ</> {{.Nasdaq.change}} ({{.Nasdaq.percent}}) at {{.Nasdaq.latest}}
-<tag>Tokyo</> {{.Tokyo.change}} ({{.Tokyo.percent}}) at {{.Tokyo.latest}} <tag>HK</> {{.HongKong.change}} ({{.HongKong.percent}}) at {{.HongKong.latest}} <tag>London</> {{.London.change}} ({{.London.percent}}) at {{.London.latest}} <tag>Frankfurt</> {{.Frankfurt.change}} ({{.Frankfurt.percent}}) at {{.Frankfurt.latest}} {{if .IsClosed}}<right>U.S. markets closed</right>{{end}}
-<tag>10-Year Yield</> {{.Yield.latest}} ({{.Yield.change}}) <tag>Euro</> ${{.Euro.latest}} ({{.Euro.change}}) <tag>Yen</> ¥{{.Yen.latest}} ({{.Yen.change}}) <tag>Oil</> ${{.Oil.latest}} ({{.Oil.change}}) <tag>Gold</> ${{.Gold.latest}} ({{.Gold.change}})`
+	markup := `<tag>Dow</> {{.Dow.Change}} ({{.Dow.Percent}}) at {{.Dow.Latest}} <tag>S&P 500</> {{.Sp500.Change}} ({{.Sp500.Percent}}) at {{.Sp500.Latest}} <tag>NASDAQ</> {{.Nasdaq.Change}} ({{.Nasdaq.Percent}}) at {{.Nasdaq.Latest}}
+<tag>Tokyo</> {{.Tokyo.Change}} ({{.Tokyo.Percent}}) at {{.Tokyo.Latest}} <tag>HK</> {{.HongKong.Change}} ({{.HongKong.Percent}}) at {{.HongKong.Latest}} <tag>London</> {{.London.Change}} ({{.London.Percent}}) at {{.London.Latest}} <tag>Frankfurt</> {{.Frankfurt.Change}} ({{.Frankfurt.Percent}}) at {{.Frankfurt.Latest}} {{if .IsClosed}}<right>U.S. markets closed</right>{{end}}
+<tag>10-Year Yield</> {{.Yield.Latest}} ({{.Yield.Change}}) <tag>Euro</> ${{.Euro.Latest}} ({{.Euro.Change}}) <tag>Yen</> ¥{{.Yen.Latest}} ({{.Yen.Change}}) <tag>Oil</> ${{.Oil.Latest}} ({{.Oil.Change}}) <tag>Gold</> ${{.Gold.Latest}} ({{.Gold.Change}})`
 
 	return template.Must(template.New(`market`).Parse(markup))
 }

--- a/layout.go
+++ b/layout.go
@@ -81,13 +81,25 @@ func (layout *Layout) Market(market *Market) string {
 		return err // then simply return the error string.
 	}
 
-	highlight(market.Dow, market.Sp500, market.Nasdaq,
-		market.Tokyo, market.HongKong, market.London, market.Frankfurt,
-		market.Yield, market.Oil, market.Euro, market.Yen, market.Gold)
+	highlight(
+		toMapSlice(
+			market.Dow, market.Sp500, market.Nasdaq,
+			market.Tokyo, market.HongKong, market.London, market.Frankfurt,
+			market.Yield, market.Oil, market.Euro, market.Yen, market.Gold,
+		)...,
+	)
 	buffer := new(bytes.Buffer)
 	layout.marketTemplate.Execute(buffer, market)
 
 	return buffer.String()
+}
+
+func toMapSlice(markets ...MarketIndex) []map[string]string {
+	result := make([]map[string]string, len(markets))
+	for i, m := range markets {
+		result[i] = m.ToMap()
+	}
+	return result
 }
 
 // Quotes uses quotes template to format timestamp, stock quotes header,

--- a/yahoo_crumb.go
+++ b/yahoo_crumb.go
@@ -97,7 +97,7 @@ func fetchCookies() string {
 	sessionID := sessionRegex.FindStringSubmatch(response.Request.URL.RawQuery)[1]
 
 	csrfRegex := regexp.MustCompile("gcrumb=(?:([A-Za-z0-9_]*))")
-	csrfToken := csrfRegex.FindStringSubmatch(response.Request.Response.Request.URL.RawQuery)[1]
+	csrfToken := csrfRegex.FindStringSubmatch(response.Request.URL.RawQuery)[1]
 
 	gucsCookie := jar.Cookies(response.Request.URL)
 	gucsCookieString := ""

--- a/yahoo_market.go
+++ b/yahoo_market.go
@@ -10,6 +10,7 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"strconv"
 )
 
 const (
@@ -135,13 +136,13 @@ func (market *Market) isMarketOpen(body []byte) []byte {
 
 // -----------------------------------------------------------------------------
 func assign(result struct {
-	RegularMarketChange        string `json:"regularMarketChange"`
-	RegularMarketPrice         string `json:"regularMarketPrice"`
-	RegularMarketChangePercent string `json:"regularMarketChangePercent"`
+	RegularMarketChange        float64 `json:"regularMarketChange"`
+	RegularMarketPrice         float64 `json:"regularMarketPrice"`
+	RegularMarketChangePercent float64 `json:"regularMarketChangePercent"`
 }, changeAsPercent bool) MarketIndex {
-	change := result.RegularMarketChange
-	latest := result.RegularMarketPrice
-	percent := result.RegularMarketChangePercent
+	change := strconv.FormatFloat(result.RegularMarketChange, 'f', 2, 64)
+	latest := strconv.FormatFloat(result.RegularMarketPrice, 'f', 2, 64)
+	percent := strconv.FormatFloat(result.RegularMarketChangePercent, 'f', 2, 64)
 
 	if changeAsPercent {
 		change += "%"
@@ -169,9 +170,9 @@ func (market *Market) extract(body []byte) *Market {
 	var d struct {
 		MarketResponse struct {
 			Result []struct {
-				RegularMarketChange        string `json:"regularMarketChange"`
-				RegularMarketPrice         string `json:"regularMarketPrice"`
-				RegularMarketChangePercent string `json:"regularMarketChangePercent"`
+				RegularMarketChange        float64 `json:"regularMarketChange"`
+				RegularMarketPrice         float64 `json:"regularMarketPrice"`
+				RegularMarketChangePercent float64 `json:"regularMarketChangePercent"`
 			} `json:"result"`
 		} `json:"quoteResponse"`
 	}

--- a/yahoo_market.go
+++ b/yahoo_market.go
@@ -10,7 +10,6 @@ import (
 	"io"
 	"net/http"
 	"net/url"
-	"strconv"
 )
 
 const (
@@ -140,14 +139,14 @@ func assign(result struct {
 	RegularMarketPrice         float64 `json:"regularMarketPrice"`
 	RegularMarketChangePercent float64 `json:"regularMarketChangePercent"`
 }, changeAsPercent bool) MarketIndex {
-	change := strconv.FormatFloat(result.RegularMarketChange, 'f', 2, 64)
-	latest := strconv.FormatFloat(result.RegularMarketPrice, 'f', 2, 64)
-	percent := strconv.FormatFloat(result.RegularMarketChangePercent, 'f', 2, 64)
+	change := float2Str(result.RegularMarketChange)
+	latest := float2Str(result.RegularMarketPrice)
+	percent := ""
 
 	if changeAsPercent {
-		change += "%"
+		change = float2Str(result.RegularMarketChangePercent) + `%`
 	} else {
-		percent += "%"
+		percent = float2Str(result.RegularMarketChangePercent) + `%`
 	}
 
 	return MarketIndex{

--- a/yahoo_quotes.go
+++ b/yahoo_quotes.go
@@ -192,29 +192,29 @@ func (quotes *Quotes) parse2(body []byte) (*Quotes, error) {
 	quotes.stocks = make([]Stock, len(d.QuoteResponse.Result))
 	for i, stock := range d.QuoteResponse.Result {
 		quotes.stocks[i].Ticker = stock.Symbol
-		quotes.stocks[i].LastTrade = strconv.FormatFloat(stock.RegularMarketPrice, 'f', 2, 64)
-		quotes.stocks[i].Change = strconv.FormatFloat(stock.RegularMarketChange, 'f', 2, 64)
-		quotes.stocks[i].ChangePct = strconv.FormatFloat(stock.RegularMarketChangePercent, 'f', 2, 64)
-		quotes.stocks[i].Open = strconv.FormatFloat(stock.RegularMarketOpen, 'f', 2, 64)
-		quotes.stocks[i].Low = strconv.FormatFloat(stock.RegularMarketDayLow, 'f', 2, 64)
-		quotes.stocks[i].High = strconv.FormatFloat(stock.RegularMarketDayHigh, 'f', 2, 64)
-		quotes.stocks[i].Low52 = strconv.FormatFloat(stock.FiftyTwoWeekLow, 'f', 2, 64)
-		quotes.stocks[i].High52 = strconv.FormatFloat(stock.FiftyTwoWeekHigh, 'f', 2, 64)
+		quotes.stocks[i].LastTrade = float2Str(stock.RegularMarketPrice)
+		quotes.stocks[i].Change = float2Str(stock.RegularMarketChange)
+		quotes.stocks[i].ChangePct = float2Str(stock.RegularMarketChangePercent)
+		quotes.stocks[i].Open = float2Str(stock.RegularMarketOpen)
+		quotes.stocks[i].Low = float2Str(stock.RegularMarketDayLow)
+		quotes.stocks[i].High = float2Str(stock.RegularMarketDayHigh)
+		quotes.stocks[i].Low52 = float2Str(stock.FiftyTwoWeekLow)
+		quotes.stocks[i].High52 = float2Str(stock.FiftyTwoWeekHigh)
 		quotes.stocks[i].Volume = float2Str(stock.RegularMarketVolume)
 		quotes.stocks[i].AvgVolume = float2Str(stock.AverageDailyVolume10Day)
-		quotes.stocks[i].PeRatio = strconv.FormatFloat(stock.TrailingPE, 'f', 2, 64)
-		quotes.stocks[i].PeRatioX = strconv.FormatFloat(stock.TrailingPE, 'f', 2, 64)
-		quotes.stocks[i].Dividend = strconv.FormatFloat(stock.TrailingAnnualDividendRate, 'f', 2, 64)
+		quotes.stocks[i].PeRatio = float2Str(stock.TrailingPE)
+		quotes.stocks[i].PeRatioX = float2Str(stock.TrailingPE)
+		quotes.stocks[i].Dividend = float2Str(stock.TrailingAnnualDividendRate)
 		if stock.TrailingAnnualDividendYield != 0 {
-			quotes.stocks[i].Yield = strconv.FormatFloat(stock.TrailingAnnualDividendYield*100, 'f', 2, 64)
+			quotes.stocks[i].Yield = float2Str(stock.TrailingAnnualDividendYield * 100)
 		} else {
 			quotes.stocks[i].Yield = noDataIndicator
 		}
 		quotes.stocks[i].MarketCap = float2Str(stock.MarketCap)
 		quotes.stocks[i].MarketCapX = float2Str(stock.MarketCap)
 		quotes.stocks[i].Currency = stock.Currency
-		quotes.stocks[i].PreOpen = strconv.FormatFloat(stock.PreMarketChangePercent, 'f', 2, 64)
-		quotes.stocks[i].AfterHours = strconv.FormatFloat(stock.PostMarketChangePercent, 'f', 2, 64)
+		quotes.stocks[i].PreOpen = float2Str(stock.PreMarketChangePercent)
+		quotes.stocks[i].AfterHours = float2Str(stock.PostMarketChangePercent)
 
 		adv := stock.RegularMarketChange
 		quotes.stocks[i].Direction = 0


### PR DESCRIPTION
Replace map usage with structs for clarity.
Created helper function in screen.go to remove some repetitive code.

@brandleesee this PR should be tested more before merging - grab it from my fork and try it out or whatever you prefer.  Formatting or math may be broken.

Probably a good reason to start writing some tests...