### PR TITLE
issue #147 ticker filter

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,11 @@ Example:
 
 This expression will make Mop show only the stocks whose `last` values are less than $5.
 
-The available properties are: `last`, `change`, `changePercent`, `open`, `low`, `high`, `low52`, `high52`, `volume`, `avgVolume`, `pe`, `peX`, `dividend`, `yield`, `mktCap`, `mktCapX` and `advancing`.
+The available properties are: `last`, `change`, `changePercent`, `open`, `low`, `high`, `low52`, `high52`, `volume`, `avgVolume`, `pe`, `peX`, `dividend`, `yield`, `mktCap`, `mktCapX`, `advancing` and `market`.
+
+Example: `market == 'L'`
+
+Note: Tickers without a suffix (e.g., `GOOG`) are assigned the `US` market.
 
 The expression **must** return a boolean value, otherwise it will fail.
 

--- a/cmd/mop/main.go
+++ b/cmd/mop/main.go
@@ -106,7 +106,7 @@ loop:
 						columnEditor = mop.NewColumnEditor(screen, quotes)
 					} else if event.Ch == 'g' || event.Ch == 'G' {
 						if profile.Regroup() == nil {
-							screen.Draw(quotes)
+							redrawQuotesFlag = true
 						}
 					} else if event.Ch == 'p' || event.Ch == 'P' {
 						paused = !paused

--- a/cmd/mop/main.go
+++ b/cmd/mop/main.go
@@ -101,6 +101,7 @@ loop:
 						lineEditor.Prompt(event.Ch)
 					} else if event.Ch == 'F' {
 						profile.SetFilter("")
+						redrawQuotesFlag = true
 					} else if event.Ch == 'o' || event.Ch == 'O' {
 						columnEditor = mop.NewColumnEditor(screen, quotes)
 					} else if event.Ch == 'g' || event.Ch == 'G' {

--- a/filter.go
+++ b/filter.go
@@ -65,6 +65,19 @@ func (filter *Filter) Apply(stocks []Stock) []Stock {
 		values["peX"] = stringToNumber(stock.PeRatioX)
 		values["direction"] = stock.Direction // Remains int.
 
+		// Extract market from ticker
+		ticker, ok := values["ticker"].(string)
+		if ok {
+			if strings.Contains(ticker, ".") {
+				parts := strings.Split(ticker, ".")
+				values["market"] = parts[len(parts)-1]
+			} else {
+				values["market"] = "US"
+			}
+		} else {
+			values["market"] = ""
+		}
+
 		result, err := filter.profile.filterExpression.Evaluate(values)
 		if err != nil {
 			// The filter isn't working, so reset to no filter.

--- a/line_editor.go
+++ b/line_editor.go
@@ -203,11 +203,11 @@ func (editor *LineEditor) execute() *LineEditor {
 			editor.hasError = true
 			termbox.Flush()
 		} else {
-			editor.screen.Draw(editor.quotes)
+			editor.screen.DrawOldQuotes(editor.quotes)
 		}
 	case 'F':
 		editor.quotes.profile.SetFilter("")
-		editor.screen.Draw(editor.quotes)
+		editor.screen.DrawOldQuotes(editor.quotes)
 	}
 
 	return editor

--- a/yahoo_quotes.go
+++ b/yahoo_quotes.go
@@ -36,8 +36,8 @@ type Stock struct {
 	High52     string `json:"fiftyTwoWeekHigh"`            // k: 52-weeks high.
 	Volume     string `json:"regularMarketVolume"`         // v: volume.
 	AvgVolume  string `json:"averageDailyVolume10Day"`     // a2: average volume.
-	PeRatio    string `json:"trailingPE"`                  // r2: P/E ration real time.
-	PeRatioX   string `json:"trailingPE"`                  // r: P/E ration (fallback when real time is N/A).
+	PeRatio    string `json:"trailingPE"`                  // r2: P/E ratio real time.
+	PeRatioX   string `json:"trailingPE"`                  // r: P/E ratio (fallback when real time is N/A).
 	Dividend   string `json:"trailingAnnualDividendRate"`  // d: dividend.
 	Yield      string `json:"trailingAnnualDividendYield"` // y: dividend yield.
 	MarketCap  string `json:"marketCap"`                   // j3: market cap real time.


### PR DESCRIPTION
Update to allow market filtering:

market == 'L'
market == 'US'
market == 'US' || market == 'L'
market IN ('US', 'L')
market != 'L'
...etc

started improving error handling.  Instead of panic, error message is displayed on the filter line if you attempt to use an invalid filter.  Ex filter:
  market == ('US' || 'L')
will cause an error message to display

Setting a filter or clearing (shift+f) will now immediately refresh the quotes display without re-fetching.